### PR TITLE
Feature/configure ruff format

### DIFF
--- a/development.md
+++ b/development.md
@@ -73,6 +73,22 @@ pytest trelliscope/tests >test-output.log
 pytest trelliscope/tests | tee test-output.log
 ```
 
+## Format code with Ruff
+
+This codebase uses Ruff to define and check codestyle.
+
+### Install linting dependencies
+
+```
+pip install -e .[lint]
+```
+
+### Run checks and formatter with Ruff
+```
+ruff check --fix .  # Lint all files in the current directory, and fix any fixable errors.
+ruff format .       # Format all files in the current directory.
+```
+
 ## Deactivate Virtual Environment
 When finished, if desired, you can deactivate the virtual environment:
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,12 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = [
-    "pytest~=7.4"
-]
 dev = [
     "trelliscope[test]",
     "ruff~=0.1"
+]
+test = [
+    "pytest~=7.4"
 ]
 
 [tool.pytest.ini_options]
@@ -55,8 +55,7 @@ select = [
     "T201", # Print Statement
     "S", # flake8-bandit
 ]
-ignore = ["E501"]  # allow too-long lines if they cannot be fixed safely, such as docstrings.
-
+ignore = ["E501", "PLR0913"]  # allow too-long lines if they cannot be fixed safely, and dont check N function arguments.
 
 [tool.ruff.isort]
 known-first-party = ["trelliscope"]
@@ -69,3 +68,6 @@ ban-relative-imports = "all"
 [tool.ruff.per-file-ignores]
 "{*/__init__.py}" = ["F401"]  # allow unused imports in __init__ files
 "{trelliscope/tests/*}" = ["S101"]  # Allow 'assert' in tests
+"{trelliscope/examples/*,trelliscope/progress_bar.py}" = ["T201"]  # Allow 'print' statements in examples and progress_bar
+[tool.mypy]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,3 @@ ban-relative-imports = "all"
 [tool.ruff.per-file-ignores]
 "{*/__init__.py}" = ["F401"]  # allow unused imports in __init__ files
 "{trelliscope/tests/*}" = ["S101"]  # Allow 'assert' in tests
-
-[tool.mypy]
-ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
+    "ruff~=0.1"
 ]
 test = [
 ]
@@ -37,3 +38,29 @@ testpaths = [
 [project.urls]
 "Homepage" = "https://github.com/trelliscope/trelliscope-py"
 "Bug Tracker" = "https://github.com/trelliscope/trelliscope-py/issues"
+
+
+[tool.ruff]
+line-length = 88
+show-fixes = true
+select = [
+    "F",   # Pyflakes
+    "W",   # pycodestyle
+    "E",   # pycodestyle
+    "I",   # isort
+    "UP",  # pyupgrade
+    "PL",  # Pylint
+    "T201", # Print Statement
+    "S", # flake8-bandit
+]
+ignore = ["E501"]  # Black take care of line-too-long
+
+[tool.ruff.isort]
+known-first-party = ["trelliscope"]
+
+[tool.ruff.flake8-tidy-imports]
+# Disallow all relative imports.
+ban-relative-imports = "all"
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,12 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = [
-    "ruff~=0.1"
-]
 test = [
+    "pytest~=7.4"
+]
+dev = [
+    "trelliscope[test]",
+    "ruff~=0.1"
 ]
 
 [tool.pytest.ini_options]
@@ -53,14 +55,20 @@ select = [
     "T201", # Print Statement
     "S", # flake8-bandit
 ]
-ignore = ["E501"]  # Black take care of line-too-long
+ignore = ["E501"]  # allow too-long lines if they cannot be fixed safely, such as docstrings.
+
 
 [tool.ruff.isort]
 known-first-party = ["trelliscope"]
 
+
 [tool.ruff.flake8-tidy-imports]
 # Disallow all relative imports.
 ban-relative-imports = "all"
+
+[tool.ruff.per-file-ignores]
+"{*/__init__.py}" = ["F401"]  # allow unused imports in __init__ files
+"{trelliscope/tests/*}" = ["S101"]  # Allow 'assert' in tests
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
First PR in a series of code-style contributions.

These are the PR's I intend to make, in order:

**1. Configure linting with [Ruff](https://docs.astral.sh/ruff/)**
2. Apply linting and checks with Ruff using Github Action.
  - Will result in linting errors because not all code would pass all checks

3 Clean up code so that Ruff linting checks are passing

4. Configure [pre-commit](https://pre-commit.com/) to automatically apply linting before commits
  - Replace Github Action to run pre-commit
  - Ensure that future contributions pass linting checks before commits and PR's
 
5 Add MyPy to pre-commit to check type-hints, as a way of validating code correctness.

# Configure Ruff as formatter

Ruff is a very fast linter and formatter, and a drop-in replacement for 'black'. It has also covered most, if not all, flake8 plugins. So Ruff is currently the only linter you need and is comfortably configured in pyproject.toml.

Ruff is configured with common plugins enabled. Looking at the codebase, I see you are double-quotes in most places, so I have configured Ruff to enforce double-quotes everywhere.

I have updated the `development.md` document to describe how to apply ruff.

### Next steps

Next, I would like to automate linting checks with Ruff  using Github Actions. This will help to ensure that future contributions follow the same code-style before merging any PR's.

But first, I would like to cleanup the codebase such that it passes the linting checks- because it does not right now. Since re-formatting PR's result in a lot of filechanges, I intend to create multiple small PR's as described in the beginning of this description.