### PR TITLE
Removed numpy from the explict dependencies list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "kaleido == 0.1.*",
     "plotly >= 5.18.0",
     "plotly-express >= 0.4.1",
-    "numpy>=1.26.2"
 ]
 version = "0.0.0-alpha1"
 authors = [


### PR DESCRIPTION
This should be handled by the pandas dependency anyway...