### PR TITLE
Phases 1–4: input system, theming, lazy panels, keysig caching, matplotlib, and 199 passing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,109 @@
 # Trelliscope
 This repository contains an experimental Python port of the trelliscope R package. It is currently under heavy development.
 
-## Getting Started
-For basic usage see the [Python Trelliscope Introduction](trelliscope/examples/introduction.ipynb) Jupyter notebook.
+## Quick Start
 
-To obtain the library while it is under heavy development, please consult the "Getting Started For Development" page for instructions on downloading and installing the package from source.
+Install from source (see [Getting Started for Development](development.md)), then try the minimal example below.
+
+### Plotly figures
+
+```python
+import pandas as pd
+import plotly.express as px
+from trelliscope import Trelliscope
+
+# One summary row per iris species, plus a per-species scatter plot
+iris = px.data.iris()
+
+rows = []
+for species, group in iris.groupby("species"):
+    fig = px.scatter(
+        group, x="sepal_width", y="sepal_length",
+        title=f"Species: {species}",
+    )
+    rows.append({
+        "species": species,
+        "n": len(group),
+        "mean_sepal_length": group["sepal_length"].mean(),
+        "panel": fig,
+    })
+
+df = pd.DataFrame(rows)
+
+(
+    Trelliscope(df, name="Iris Species", path="./iris_display")
+    .set_var_labels(
+        species="Species",
+        n="Count",
+        mean_sepal_length="Mean Sepal Length (cm)",
+    )
+    .set_default_layout(ncol=3)
+    .write_display()
+    .view_trelliscope()
+)
+```
+
+### Lazy panels (generate figures at write time)
+
+Use `LazyPanel` when you want to generate each figure from a row of the summary
+data frame rather than pre-computing all figures up front.  The function
+receives a `pd.Series` (one row) and must return a Plotly or matplotlib figure.
+
+```python
+import pandas as pd
+import plotly.express as px
+from trelliscope import LazyPanel, Trelliscope
+
+iris = px.data.iris()
+summary = (
+    iris.groupby("species")
+    .agg(n=("sepal_length", "count"), mean_sl=("sepal_length", "mean"))
+    .reset_index()
+)
+
+# Keep the raw data accessible in the closure
+def make_panel(row):
+    species_data = iris[iris["species"] == row["species"]]
+    return px.scatter(species_data, x="sepal_width", y="sepal_length",
+                      title=row["species"])
+
+(
+    Trelliscope(summary, name="Iris Lazy", path="./iris_lazy")
+    .add_panel(LazyPanel("panel", fn=make_panel))
+    .write_display()
+)
+```
+
+### matplotlib figures
+
+`Trelliscope` also accepts `matplotlib.figure.Figure` objects in panel columns
+(or returned from a `LazyPanel` function).
+
+```python
+import matplotlib.pyplot as plt
+import pandas as pd
+import plotly.express as px  # for the iris dataset only
+from trelliscope import Trelliscope
+
+iris = px.data.iris()
+
+rows = []
+for species, group in iris.groupby("species"):
+    fig, ax = plt.subplots()
+    ax.scatter(group["sepal_width"], group["sepal_length"])
+    ax.set_title(species)
+    rows.append({"species": species, "panel": fig})
+    plt.close(fig)
+
+df = pd.DataFrame(rows)
+Trelliscope(df, name="Iris matplotlib", path="./iris_mpl").write_display()
+```
+
+## More Examples
+
+For a fuller walkthrough see the
+[Python Trelliscope Introduction](trelliscope/examples/introduction.ipynb)
+Jupyter notebook.
 
 ## Getting Started For Development
 If you are interested in working on development of the Trelliscope library itself, see: [Getting Started for Development](development.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = ["trelliscope/tests"]
 name = "trelliscope"
 dependencies = [
     "pandas >= 1.5.2",
-    "kaleido == 0.1.*",
+    "kaleido >= 0.2.0",
     "plotly >= 5.18.0",
     "plotly-express >= 0.4.1",
     "importlib_resources;python_version<'3.9'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = ["trelliscope/tests"]
 name = "trelliscope"
 dependencies = [
     "pandas >= 1.5.2",
-    "kaleido >= 0.2.0",
+    "kaleido",
     "plotly >= 5.18.0",
     "plotly-express >= 0.4.1",
     "importlib_resources;python_version<'3.9'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "trelliscope"
 dependencies = [
     "pandas >= 1.5.2",
     "kaleido",
-    "plotly >= 5.18.0",
+    "plotly >= 5.19.0",
     "plotly-express >= 0.4.1",
     "importlib_resources;python_version<'3.9'"
 ]

--- a/trelliscope/__init__.py
+++ b/trelliscope/__init__.py
@@ -7,4 +7,5 @@ from trelliscope.input import (
     SelectInput,
     TextInput,
 )
+from trelliscope.theme import Theme
 from trelliscope.trelliscope import Trelliscope

--- a/trelliscope/__init__.py
+++ b/trelliscope/__init__.py
@@ -7,5 +7,6 @@ from trelliscope.input import (
     SelectInput,
     TextInput,
 )
+from trelliscope.panels import LazyPanel
 from trelliscope.theme import Theme
 from trelliscope.trelliscope import Trelliscope

--- a/trelliscope/__init__.py
+++ b/trelliscope/__init__.py
@@ -1,1 +1,10 @@
+from trelliscope.input import (
+    CheckboxInput,
+    Input,
+    MultiselectInput,
+    NumberInput,
+    RadioInput,
+    SelectInput,
+    TextInput,
+)
 from trelliscope.trelliscope import Trelliscope

--- a/trelliscope/input.py
+++ b/trelliscope/input.py
@@ -1,6 +1,24 @@
+from __future__ import annotations
+
+import json
+
+
 class Input:
-    def __init__(self):
-        self._name = ""
+    """Base class for all user annotation input types."""
+
+    TYPE_TEXT = "text"
+    TYPE_NUMBER = "number"
+    TYPE_RADIO = "radio"
+    TYPE_CHECKBOX = "checkbox"
+    TYPE_SELECT = "select"
+    TYPE_MULTISELECT = "multiselect"
+
+    def __init__(self, type: str, name: str, label: str = None):
+        if not isinstance(name, str) or not name:
+            raise ValueError("Input 'name' must be a non-empty string.")
+        self._name = name
+        self.type = type
+        self.label = label if label is not None else name
 
     @property
     def name(self):
@@ -8,4 +26,123 @@ class Input:
 
     @name.setter
     def name(self, value):
+        if not isinstance(value, str) or not value:
+            raise ValueError("Input 'name' must be a non-empty string.")
         self._name = value
+
+    def to_dict(self) -> dict:
+        return {"name": self._name, "label": self.label, "type": self.type}
+
+    def to_json(self, pretty: bool = True) -> str:
+        return json.dumps(self.to_dict(), indent=2 if pretty else None)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(name={self._name!r}, label={self.label!r})"
+
+
+class TextInput(Input):
+    """Free-form multi-line text annotation input."""
+
+    def __init__(self, name: str, label: str = None, width: int = 80, height: int = 3):
+        super().__init__(Input.TYPE_TEXT, name, label)
+        if not isinstance(width, int) or width <= 0:
+            raise ValueError("TextInput 'width' must be a positive integer.")
+        if not isinstance(height, int) or height <= 0:
+            raise ValueError("TextInput 'height' must be a positive integer.")
+        self.width = width
+        self.height = height
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        d["width"] = self.width
+        d["height"] = self.height
+        return d
+
+
+class NumberInput(Input):
+    """Numeric annotation input with optional min/max bounds."""
+
+    def __init__(
+        self,
+        name: str,
+        label: str = None,
+        min: float = None,
+        max: float = None,
+    ):
+        super().__init__(Input.TYPE_NUMBER, name, label)
+        if min is not None and not isinstance(min, (int, float)):
+            raise ValueError("NumberInput 'min' must be numeric.")
+        if max is not None and not isinstance(max, (int, float)):
+            raise ValueError("NumberInput 'max' must be numeric.")
+        if min is not None and max is not None and min > max:
+            raise ValueError("NumberInput 'min' must not exceed 'max'.")
+        self.min = min
+        self.max = max
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        if self.min is not None:
+            d["min"] = self.min
+        if self.max is not None:
+            d["max"] = self.max
+        return d
+
+
+class RadioInput(Input):
+    """Single-choice radio button annotation input."""
+
+    def __init__(self, name: str, label: str = None, options: list = None):
+        super().__init__(Input.TYPE_RADIO, name, label)
+        if options is None or not isinstance(options, list) or len(options) == 0:
+            raise ValueError("RadioInput 'options' must be a non-empty list.")
+        self.options = options
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        d["options"] = self.options
+        return d
+
+
+class CheckboxInput(Input):
+    """Multi-choice checkbox annotation input."""
+
+    def __init__(self, name: str, label: str = None, options: list = None):
+        super().__init__(Input.TYPE_CHECKBOX, name, label)
+        if options is None or not isinstance(options, list) or len(options) == 0:
+            raise ValueError("CheckboxInput 'options' must be a non-empty list.")
+        self.options = options
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        d["options"] = self.options
+        return d
+
+
+class SelectInput(Input):
+    """Single-choice dropdown annotation input."""
+
+    def __init__(self, name: str, label: str = None, options: list = None):
+        super().__init__(Input.TYPE_SELECT, name, label)
+        if options is None or not isinstance(options, list) or len(options) == 0:
+            raise ValueError("SelectInput 'options' must be a non-empty list.")
+        self.options = options
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        d["options"] = self.options
+        return d
+
+
+class MultiselectInput(Input):
+    """Multi-choice dropdown annotation input."""
+
+    def __init__(self, name: str, label: str = None, options: list = None):
+        super().__init__(Input.TYPE_MULTISELECT, name, label)
+        if options is None or not isinstance(options, list) or len(options) == 0:
+            raise ValueError("MultiselectInput 'options' must be a non-empty list.")
+        self.options = options
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        d["options"] = self.options
+        return d

--- a/trelliscope/metas.py
+++ b/trelliscope/metas.py
@@ -349,19 +349,16 @@ class FactorMeta(Meta):
 
     def cast_variable(self, df: pd.DataFrame) -> pd.DataFrame:
         """
-        Converts the `self.varname` column in the data frame to be a string type.
-        This will change the original data frame.
+        Converts the `self.varname` column to a pandas Categorical with the
+        factor levels. Levels are inferred from the data if not already set.
         Params:
             df: Pandas DataFrame
         Returns:
             The updated Pandas DataFrame
         """
-        # TODO: This seems we should cast it to a categorical variable
-        # rather than just a string. And it seems like this would be a
-        # better place to actual infer the levels than the "check_variable"
-        # function above.
-        raise NotImplementedError()
-        df[self.varname] = df[self.varname].astype(str)
+        if self.levels is None:
+            self.infer_levels(df)
+        df[self.varname] = pd.Categorical(df[self.varname], categories=self.levels)
         return df
 
 
@@ -481,15 +478,23 @@ class GeoMeta(Meta):
         utils.check_latitude_variable(df, self.latvar, self._get_data_error_message)
         utils.check_longitude_variable(df, self.longvar, self._get_data_error_message)
 
-    # TODO: add a cast variable function that converts lat and long into a single var name
+    def cast_variable(self, df: pd.DataFrame) -> pd.DataFrame:
+        """
+        Validates that latvar and longvar columns are numeric and in the correct
+        geographic ranges. Returns the dataframe unchanged (no coercion needed
+        since the viewer reads latvar/longvar columns directly).
+        Params:
+            df: Pandas DataFrame
+        Returns:
+            The Pandas DataFrame (unchanged)
+        """
+        self.check_variable(df)
+        return df
 
     def to_dict(self) -> dict:
-        # Overriding to make it so latvar and longvar are not serialized
         result = self.__dict__.copy()
-
-        result.pop("latvar", None)
-        result.pop("longvar", None)
-
+        if self.label is None:
+            result["label"] = self.varname
         return result
 
 

--- a/trelliscope/metas.py
+++ b/trelliscope/metas.py
@@ -288,11 +288,13 @@ class PanelMeta(Meta):
         return result
 
     def check_variable(self, df: pd.DataFrame):
-        """
-        Checks that the variable is an appropriate type for panels.
-        """
-        # TODO: Fill this in
-        pass
+        """Checks that the panel column exists in the dataframe."""
+        if self.varname not in df.columns:
+            raise ValueError(
+                self._get_data_error_message(
+                    f"Panel column '{self.varname}' is not present in the data frame."
+                )
+            )
 
 
 class FactorMeta(Meta):
@@ -390,7 +392,13 @@ class DatetimeMeta(Meta):
             sortable=True,
         )
 
-        # TODO: Consider validating timezone
+        if not isinstance(timezone, str):
+            raise TypeError(
+                f"timezone must be a string (e.g. 'UTC', 'America/New_York'), "
+                f"got {type(timezone).__name__}."
+            )
+        if not timezone.strip():
+            raise ValueError("timezone must not be an empty string.")
 
         self.timezone = timezone
 
@@ -447,6 +455,11 @@ class GraphMeta(Meta):
         utils.check_graph_var(
             df, self.varname, self.idvarname, self._get_data_error_message
         )
+
+    def cast_variable(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Validates graph column structure. Returns the dataframe unchanged."""
+        self.check_variable(df)
+        return df
 
 
 class GeoMeta(Meta):

--- a/trelliscope/panels.py
+++ b/trelliscope/panels.py
@@ -62,6 +62,7 @@ class Panel:
         self.aspect_ratio = aspect_ratio
         self.is_image = is_image
         self.is_writeable = writeable
+        self.is_lazy = False
         self.should_copy = False
         self.source = source
         self.panel_type_str = panel_type_str
@@ -105,6 +106,10 @@ class Panel:
         # It is not already determined to be an image or figure column
         # Check to see if it is one of these before proceeding
         if not (is_known_image_col or is_known_figure_col):
+            # Check for a lazy panel (column filled with callables)
+            if utils.is_callable_column(df, panel_column):
+                fn = df[panel_column][0]
+                return LazyPanel(panel_column, fn=fn)
             if utils.is_image_column(df, panel_column):
                 is_known_image_col = True
             elif utils.is_figure_column(df, panel_column):
@@ -219,5 +224,42 @@ class FigurePanel(Panel):
     def get_extension(self) -> str:
         return self.extension
 
-    # def get_panel_source(self) -> dict:
-    #     return {"type": "file"}
+
+class LazyPanel(Panel):
+    """
+    A panel generated lazily at write time by calling a user-supplied function
+    for each row of the data frame.
+
+    The function receives a DataFrame row (pd.Series) and must return a figure
+    object (Plotly or matplotlib).
+    """
+
+    def __init__(
+        self,
+        varname: str,
+        fn,
+        extension: str = "png",
+        aspect_ratio: float = 1.5,
+    ) -> None:
+        if not callable(fn):
+            raise ValueError(
+                "'fn' must be a callable that accepts a DataFrame row and returns a figure."
+            )
+        super().__init__(
+            varname=varname,
+            panel_type_str=Panel._PANEL_TYPE_IMAGE,
+            source=FilePanelSource(is_local=True),
+            aspect_ratio=aspect_ratio,
+            is_image=False,
+            writeable=True,
+        )
+        self.fn = fn
+        self.is_lazy = True
+        self.extension = extension
+        self.figure_varname = self.varname + Panel._FIGURE_SUFFIX
+
+    def get_extension(self) -> str:
+        return self.extension
+
+    def check_valid(self, df: pd.DataFrame):
+        pass  # lazy panels don't require a pre-existing column

--- a/trelliscope/state.py
+++ b/trelliscope/state.py
@@ -80,25 +80,45 @@ class State:
 class LayoutState(State):
     VIEWTYPE_GRID = "grid"
 
-    def __init__(self, ncol: int = 1, page: int = 1):
+    def __init__(
+        self,
+        ncol: int = 1,
+        page: int = 1,
+        sidebar: bool = True,
+        visible_filters: list = None,
+    ):
         """
         Params:
-            ncol: int - Number of cols
-            page: int - Number of pages
+            ncol: int - Number of columns in the panel grid.
+            page: int - Initial page number.
+            sidebar: bool - Whether the filter sidebar is open by default.
+            visible_filters: list - Variable names whose filter controls are
+                expanded in the sidebar by default. None means all are collapsed.
         """
         super().__init__(State.TYPE_LAYOUT)
 
         utils.check_int(ncol, "ncol")
         utils.check_int(page, "page")
+        utils.check_bool(sidebar, "sidebar")
+
+        if visible_filters is not None:
+            utils.check_is_list(visible_filters, self._get_error_message)
 
         self.ncol = ncol
         self.page = page
+        self.sidebar = sidebar
+        self.visible_filters = visible_filters
         self.viewtype = LayoutState.VIEWTYPE_GRID
 
     def check_with_data(self, df: pd.DataFrame):
-        # This comment is in the R version:
-        # TODO: could check to see if "page" makes sense after applying filters
-        # and accounting for nrow and ncol
+        if self.visible_filters is not None:
+            extra = set(self.visible_filters) - set(df.columns)
+            if extra:
+                raise ValueError(
+                    self._get_data_error_message(
+                        f"visible_filters references columns not in the data: {extra}"
+                    )
+                )
         return True
 
 

--- a/trelliscope/tests/test_infer.py
+++ b/trelliscope/tests/test_infer.py
@@ -1,0 +1,233 @@
+import tempfile
+
+import pandas as pd
+import pytest
+
+from trelliscope import LazyPanel, Trelliscope
+from trelliscope.metas import (
+    FactorMeta,
+    HrefMeta,
+    NumberMeta,
+    PanelMeta,
+    StringMeta,
+)
+from trelliscope.panel_source import FilePanelSource
+from trelliscope.panels import FigurePanel, ImagePanel, Panel
+
+
+# ---------------------------------------------------------------------------
+# Key-column inference
+# ---------------------------------------------------------------------------
+
+
+def test_infer_key_cols_single_string(iris_df_no_duplicates):
+    """A column of unique strings should be inferred as the key column."""
+    df = iris_df_no_duplicates.copy()
+    df.insert(0, "id", [f"row_{i}" for i in range(len(df))])
+    tr = Trelliscope(df, "test")
+    assert "id" in tr.key_cols
+
+
+def test_infer_key_cols_multiple_columns(iris_df):
+    """When no single column is unique, multiple columns should be combined."""
+    # iris_df has duplicates; Species + Sepal.Length combination may uniquely identify rows
+    tr = Trelliscope(iris_df.drop_duplicates(), "test")
+    # key_cols should be non-empty
+    assert len(tr.key_cols) > 0
+
+
+def test_infer_key_cols_raises_when_no_unique_combo(iris_df):
+    """Should raise if no column combination uniquely identifies rows."""
+    # Duplicate rows make key-col inference fail
+    df = pd.DataFrame({"a": [1, 1], "b": [2, 2]})
+    with pytest.raises(ValueError, match="Could not find columns"):
+        Trelliscope(df, "test")
+
+
+# ---------------------------------------------------------------------------
+# Meta type inference
+# ---------------------------------------------------------------------------
+
+
+def test_infer_number_meta(iris_df_no_duplicates):
+    tr = Trelliscope(iris_df_no_duplicates, "test")
+    tr = tr.infer()
+    assert "Sepal.Length" in tr.metas
+    assert isinstance(tr.metas["Sepal.Length"], NumberMeta)
+
+
+def test_infer_string_meta(iris_df_no_duplicates):
+    tr = Trelliscope(iris_df_no_duplicates, "test")
+    tr = tr.infer()
+    # Species is a string (object dtype, first value is str)
+    assert "Species" in tr.metas
+    assert isinstance(tr.metas["Species"], StringMeta)
+
+
+def test_infer_factor_meta(iris_df_no_duplicates):
+    df = iris_df_no_duplicates.copy()
+    df["Species"] = pd.Categorical(df["Species"])
+    tr = Trelliscope(df, "test")
+    tr = tr.infer()
+    assert "Species" in tr.metas
+    assert isinstance(tr.metas["Species"], FactorMeta)
+
+
+def test_infer_href_meta(iris_df_no_duplicates):
+    df = iris_df_no_duplicates.copy()
+    df["url"] = [f"https://example.com/{i}" for i in range(len(df))]
+    tr = Trelliscope(df, "test")
+    tr = tr.infer()
+    assert "url" in tr.metas
+    assert isinstance(tr.metas["url"], HrefMeta)
+
+
+def test_infer_skips_non_meta_columns(iris_df_no_duplicates):
+    """Object columns that are not strings, figures, or callables should be ignored."""
+    df = iris_df_no_duplicates.copy()
+    df["mixed"] = [{"key": i} for i in range(len(df))]
+    tr = Trelliscope(df, "test")
+    tr = tr.infer()
+    assert "mixed" not in tr.metas
+    assert "mixed" in tr.columns_to_ignore
+
+
+# ---------------------------------------------------------------------------
+# Panel column exclusion from metas
+# ---------------------------------------------------------------------------
+
+
+def test_panel_column_becomes_panel_meta(iris_df_no_duplicates):
+    df = iris_df_no_duplicates.copy()
+    df["img_panel"] = "test_image.png"
+    pnl = ImagePanel("img_panel", source=FilePanelSource(is_local=False), should_copy_to_output=False)
+    tr = Trelliscope(df, "test").add_panel(pnl)
+    tr = tr.infer()
+    assert "img_panel" in tr.metas
+    assert isinstance(tr.metas["img_panel"], PanelMeta)
+
+
+def test_panel_column_not_inferred_as_string_meta(iris_df_no_duplicates):
+    df = iris_df_no_duplicates.copy()
+    df["img_panel"] = "test_image.png"
+    pnl = ImagePanel("img_panel", source=FilePanelSource(is_local=False), should_copy_to_output=False)
+    tr = Trelliscope(df, "test").add_panel(pnl)
+    tr = tr.infer()
+    assert isinstance(tr.metas["img_panel"], PanelMeta)
+    assert not isinstance(tr.metas["img_panel"], StringMeta)
+
+
+# ---------------------------------------------------------------------------
+# Figure backup column exclusion from metas
+# ---------------------------------------------------------------------------
+
+
+def test_figure_backup_column_excluded_from_metas(iris_df_no_duplicates):
+    """The __FIGURE backup column should never appear in metas."""
+    df = iris_df_no_duplicates.copy()
+    df["img_panel"] = "test_image.png"
+    pnl = ImagePanel("img_panel", source=FilePanelSource(is_local=False), should_copy_to_output=False)
+    tr = Trelliscope(df, "test").add_panel(pnl)
+    tr = tr.infer()
+    backup_col = "img_panel" + Panel._FIGURE_SUFFIX
+    assert backup_col not in tr.metas
+
+
+# ---------------------------------------------------------------------------
+# Panel inference from image columns
+# ---------------------------------------------------------------------------
+
+
+def test_infer_panels_from_image_column(iris_df_no_duplicates):
+    df = iris_df_no_duplicates.copy()
+    df["img_panel"] = "test_image.png"
+    pnl = ImagePanel("img_panel", source=FilePanelSource(is_local=False), should_copy_to_output=False)
+    tr = Trelliscope(df, "test").add_panel(pnl)
+    tr = tr.infer_panels()
+    assert "img_panel" in tr._get_panel_columns()
+    assert isinstance(tr._get_panel("img_panel"), ImagePanel)
+
+
+# ---------------------------------------------------------------------------
+# LazyPanel inference from callable column
+# ---------------------------------------------------------------------------
+
+
+def test_infer_panels_detects_callable_column(iris_df_no_duplicates):
+    """A column of callables should be auto-detected as a LazyPanel."""
+    from trelliscope.panels import LazyPanel as LP
+
+    df = iris_df_no_duplicates.copy()
+    df["lazy"] = [lambda row: None for _ in range(len(df))]
+    tr = Trelliscope(df, "test")
+    tr = tr.infer_panels()
+    assert "lazy" in tr._get_panel_columns()
+    assert isinstance(tr._get_panel("lazy"), LP)
+
+
+def test_lazy_panel_explicit_add(iris_df_no_duplicates):
+    """LazyPanel added explicitly should appear in panel columns."""
+    from trelliscope.panels import LazyPanel as LP
+
+    df = iris_df_no_duplicates.copy()
+    fn = lambda row: None  # noqa: E731
+    lp = LP("lazy_panel", fn=fn)
+    tr = Trelliscope(df, "test").add_panel(lp)
+    assert "lazy_panel" in tr._get_panel_columns()
+
+
+def test_lazy_panel_invalid_fn():
+    from trelliscope.panels import LazyPanel as LP
+
+    with pytest.raises(ValueError, match="callable"):
+        LP("panel", fn="not_a_function")
+
+
+# ---------------------------------------------------------------------------
+# Label inference fallback
+# ---------------------------------------------------------------------------
+
+
+def test_infer_labels_fall_back_to_varname(iris_df_no_duplicates):
+    """When no var_labels are set, the label should default to the varname."""
+    tr = Trelliscope(iris_df_no_duplicates, "test")
+    tr = tr.infer()
+    assert tr.metas["Sepal.Length"].label == "Sepal.Length"
+
+
+def test_infer_labels_uses_set_var_labels(iris_df_no_duplicates):
+    """set_var_labels() should propagate to inferred metas."""
+    tr = (
+        Trelliscope(iris_df_no_duplicates, "test")
+        .set_var_labels(**{"Sepal.Length": "Sepal Length (cm)"})
+        .infer()
+    )
+    assert tr.metas["Sepal.Length"].label == "Sepal Length (cm)"
+
+
+# ---------------------------------------------------------------------------
+# Default state inference
+# ---------------------------------------------------------------------------
+
+
+def test_infer_default_layout_state(iris_df_no_duplicates):
+    """When no layout is set, infer() should supply a default LayoutState."""
+    df = iris_df_no_duplicates.copy()
+    df["img_panel"] = "test_image.png"
+    pnl = ImagePanel("img_panel", source=FilePanelSource(is_local=False), should_copy_to_output=False)
+    tr = Trelliscope(df, "test").add_panel(pnl)
+    tr = tr.infer()
+    assert tr.state.layout is not None
+    assert tr.state.layout.ncol == 3
+
+
+def test_infer_default_label_state(iris_df_no_duplicates):
+    """When no labels are set, infer() should supply labels defaulting to key_cols."""
+    df = iris_df_no_duplicates.copy()
+    df["img_panel"] = "test_image.png"
+    pnl = ImagePanel("img_panel", source=FilePanelSource(is_local=False), should_copy_to_output=False)
+    tr = Trelliscope(df, "test").add_panel(pnl)
+    tr = tr.infer()
+    assert tr.state.labels is not None
+    for key in tr.key_cols:
+        assert key in tr.state.labels.varnames

--- a/trelliscope/tests/test_input.py
+++ b/trelliscope/tests/test_input.py
@@ -1,0 +1,217 @@
+import json
+
+import pytest
+
+from trelliscope.input import (
+    CheckboxInput,
+    Input,
+    MultiselectInput,
+    NumberInput,
+    RadioInput,
+    SelectInput,
+    TextInput,
+)
+
+
+# ---------------------------------------------------------------------------
+# TextInput
+# ---------------------------------------------------------------------------
+
+
+def test_text_input_defaults():
+    inp = TextInput("notes")
+    assert inp.name == "notes"
+    assert inp.label == "notes"
+    assert inp.type == Input.TYPE_TEXT
+    assert inp.width == 80
+    assert inp.height == 3
+
+
+def test_text_input_custom():
+    inp = TextInput("comments", label="My Comments", width=60, height=5)
+    assert inp.label == "My Comments"
+    assert inp.width == 60
+    assert inp.height == 5
+
+
+def test_text_input_to_dict():
+    inp = TextInput("notes", label="Notes", width=80, height=4)
+    d = inp.to_dict()
+    assert d == {"name": "notes", "label": "Notes", "type": "text", "width": 80, "height": 4}
+
+
+def test_text_input_to_json():
+    inp = TextInput("notes")
+    parsed = json.loads(inp.to_json())
+    assert parsed["type"] == "text"
+
+
+def test_text_input_invalid_width():
+    with pytest.raises(ValueError, match="width"):
+        TextInput("notes", width=0)
+
+
+def test_text_input_invalid_height():
+    with pytest.raises(ValueError, match="height"):
+        TextInput("notes", height=-1)
+
+
+# ---------------------------------------------------------------------------
+# NumberInput
+# ---------------------------------------------------------------------------
+
+
+def test_number_input_defaults():
+    inp = NumberInput("score")
+    assert inp.name == "score"
+    assert inp.type == Input.TYPE_NUMBER
+    assert inp.min is None
+    assert inp.max is None
+
+
+def test_number_input_with_bounds():
+    inp = NumberInput("score", label="Quality Score", min=0, max=10)
+    assert inp.min == 0
+    assert inp.max == 10
+
+
+def test_number_input_to_dict():
+    inp = NumberInput("score", min=1, max=5)
+    d = inp.to_dict()
+    assert d["min"] == 1
+    assert d["max"] == 5
+    assert d["type"] == "number"
+
+
+def test_number_input_to_dict_no_bounds():
+    inp = NumberInput("score")
+    d = inp.to_dict()
+    assert "min" not in d
+    assert "max" not in d
+
+
+def test_number_input_invalid_bounds():
+    with pytest.raises(ValueError, match="min.*max|max.*min"):
+        NumberInput("score", min=10, max=5)
+
+
+def test_number_input_invalid_min_type():
+    with pytest.raises(ValueError, match="numeric"):
+        NumberInput("score", min="bad")
+
+
+# ---------------------------------------------------------------------------
+# RadioInput
+# ---------------------------------------------------------------------------
+
+
+def test_radio_input():
+    inp = RadioInput("quality", label="Quality", options=["good", "bad", "ugly"])
+    assert inp.type == Input.TYPE_RADIO
+    assert inp.options == ["good", "bad", "ugly"]
+
+
+def test_radio_input_to_dict():
+    inp = RadioInput("quality", options=["yes", "no"])
+    d = inp.to_dict()
+    assert d["options"] == ["yes", "no"]
+    assert d["type"] == "radio"
+
+
+def test_radio_input_empty_options():
+    with pytest.raises(ValueError, match="options"):
+        RadioInput("quality", options=[])
+
+
+def test_radio_input_none_options():
+    with pytest.raises(ValueError, match="options"):
+        RadioInput("quality", options=None)
+
+
+# ---------------------------------------------------------------------------
+# CheckboxInput
+# ---------------------------------------------------------------------------
+
+
+def test_checkbox_input():
+    inp = CheckboxInput("tags", options=["a", "b", "c"])
+    assert inp.type == Input.TYPE_CHECKBOX
+    assert len(inp.options) == 3
+
+
+def test_checkbox_input_to_dict():
+    inp = CheckboxInput("tags", label="Tags", options=["x", "y"])
+    d = inp.to_dict()
+    assert d["type"] == "checkbox"
+    assert d["options"] == ["x", "y"]
+
+
+def test_checkbox_input_invalid_options():
+    with pytest.raises(ValueError, match="options"):
+        CheckboxInput("tags", options="not-a-list")
+
+
+# ---------------------------------------------------------------------------
+# SelectInput
+# ---------------------------------------------------------------------------
+
+
+def test_select_input():
+    inp = SelectInput("category", options=["A", "B", "C"])
+    assert inp.type == Input.TYPE_SELECT
+
+
+def test_select_input_to_dict():
+    inp = SelectInput("category", label="Category", options=["A", "B"])
+    d = inp.to_dict()
+    assert d["type"] == "select"
+    assert d["options"] == ["A", "B"]
+
+
+def test_select_input_invalid_options():
+    with pytest.raises(ValueError, match="options"):
+        SelectInput("category", options=[])
+
+
+# ---------------------------------------------------------------------------
+# MultiselectInput
+# ---------------------------------------------------------------------------
+
+
+def test_multiselect_input():
+    inp = MultiselectInput("tags", options=["x", "y", "z"])
+    assert inp.type == Input.TYPE_MULTISELECT
+
+
+def test_multiselect_input_to_dict():
+    inp = MultiselectInput("tags", label="Tags", options=["p", "q"])
+    d = inp.to_dict()
+    assert d["type"] == "multiselect"
+    assert d["options"] == ["p", "q"]
+
+
+def test_multiselect_input_invalid_options():
+    with pytest.raises(ValueError, match="options"):
+        MultiselectInput("tags", options=None)
+
+
+# ---------------------------------------------------------------------------
+# Base Input validation
+# ---------------------------------------------------------------------------
+
+
+def test_input_empty_name():
+    with pytest.raises(ValueError, match="name"):
+        TextInput("")
+
+
+def test_input_name_setter_validation():
+    inp = TextInput("notes")
+    with pytest.raises(ValueError, match="name"):
+        inp.name = ""
+
+
+def test_input_repr():
+    inp = RadioInput("q", label="Quality", options=["good"])
+    assert "RadioInput" in repr(inp)
+    assert "q" in repr(inp)

--- a/trelliscope/tests/test_metas.py
+++ b/trelliscope/tests/test_metas.py
@@ -208,6 +208,31 @@ def test_factor_meta(iris_df):
         FactorMeta("Species", levels="this is a string")
 
 
+def test_factor_meta_cast_variable(iris_df):
+    # Use a fresh DataFrame where Species is plain string (not yet Categorical)
+    import pandas as pd
+
+    df = pd.DataFrame({"Species": ["setosa", "versicolor", "virginica", "setosa"]})
+    assert df["Species"].dtype.name != "category"
+
+    meta = FactorMeta("Species")
+    df2 = meta.cast_variable(df)
+
+    assert df2["Species"].dtype.name == "category"
+    assert set(df2["Species"].cat.categories.tolist()) == {"setosa", "versicolor", "virginica"}
+
+
+def test_factor_meta_cast_variable_with_explicit_levels(iris_df):
+    levels = ["setosa", "virginica", "versicolor", "extra"]
+    meta = FactorMeta("Species", levels=levels)
+
+    df2 = meta.cast_variable(iris_df)
+
+    assert df2["Species"].dtype.name == "category"
+    # All declared levels should be present as categories (even unused ones)
+    assert set(levels).issubset(set(df2["Species"].cat.categories.tolist()))
+
+
 def test_date_meta(iris_plus_df: pd.DataFrame):
     meta = DateMeta("date")
     meta.check_with_data(iris_plus_df)
@@ -236,12 +261,64 @@ def test_geo_meta(iris_plus_df):
     meta.check_with_data(iris_plus_df)
 
 
-@pytest.mark.skip("Feature is not implemented yet")
-def test_graph_meta(iris_plus_df):
-    # TODO: The iris_plus_df will need to have extra columns added for this
+def test_geo_meta_to_dict_includes_latvar_longvar(iris_plus_df):
+    meta = GeoMeta("coords", latvar="lat", longvar="long", label="Location")
+    d = meta.to_dict()
+    assert d["latvar"] == "lat"
+    assert d["longvar"] == "long"
+    assert d["varname"] == "coords"
+    assert d["label"] == "Location"
+    assert d["type"] == "geo"
 
-    meta = GraphMeta("lst", "id", "to")
-    meta.check_with_data(iris_plus_df)
+
+def test_geo_meta_cast_variable(iris_plus_df):
+    meta = GeoMeta("coords", latvar="lat", longvar="long")
+    df2 = meta.cast_variable(iris_plus_df)
+    # cast_variable validates and returns dataframe unchanged
+    assert "lat" in df2.columns
+    assert "long" in df2.columns
+
+
+def test_graph_meta(iris_plus_df):
+    # Build a dataframe with a valid graph column
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "links": [
+                [{"id": 2}, {"id": 3}],
+                [{"id": 1}],
+                [],
+            ],
+        }
+    )
+
+    meta = GraphMeta("links", idvarname="id", direction="to")
+    meta.check_with_data(df)
+
+
+def test_graph_meta_invalid_non_list(iris_plus_df):
+    import pandas as pd
+
+    df = pd.DataFrame({"id": [1, 2], "links": ["not-a-list", "also-not"]})
+    meta = GraphMeta("links", idvarname="id")
+    with pytest.raises(ValueError, match="list of dicts"):
+        meta.check_with_data(df)
+
+
+def test_graph_meta_missing_id_key():
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "id": [1],
+            "links": [[{"wrong_key": 2}]],
+        }
+    )
+    meta = GraphMeta("links", idvarname="id")
+    with pytest.raises(ValueError, match="missing required key"):
+        meta.check_with_data(df)
 
 
 def test_href_meta(iris_plus_df):

--- a/trelliscope/tests/test_panels.py
+++ b/trelliscope/tests/test_panels.py
@@ -45,53 +45,43 @@ def test_panels_setup(iris_df_no_duplicates: pd.DataFrame):
         )
 
 
-@pytest.mark.skip("Still considering various options for this")
-def test_panels_setup_options(iris_df: pd.DataFrame):
-    with tempfile.TemporaryDirectory() as temp_dir_name:
-        tr = Trelliscope(iris_df, "Iris", path=temp_dir_name)
+def test_panels_setup_options(iris_df_no_duplicates: pd.DataFrame):
+    df = iris_df_no_duplicates.copy()
+    df["img_panel"] = "test_image.png"
+    pnl = ImagePanel(
+        "img_panel",
+        source=FilePanelSource(is_local=False),
+        should_copy_to_output=False,
+    )
 
-        # This will infer the panels if they have not been set
-        tr.write_display()
-
-        # this is test code that just sets all images to this test_image.png string
-        # it is not a proper use of the images, but gives us something to use in testing.
-        iris_df["img_panel"] = "test_image.png"
-
-        # use panel in init
-        pnl = Panel("img_panel", aspect_ratio=1.5)
-        tr = Trelliscope(iris_df, "Iris", panel=pnl, path=temp_dir_name)
-        tr.write_display()
-
-        # set panel after init
-        tr = Trelliscope(iris_df, "Iris", path=temp_dir_name)
-        tr.set_panel(Panel("img_panel", aspect_ratio=1.5))
-
-        tr.write_display()
-
-        # set derived class panel
-        tr = Trelliscope(iris_df, "Iris", path=temp_dir_name)
-        tr.set_panel(ImagePanel("img_panel", aspect_ratio=1.5))
-        tr.write_display()
-
-        # set derived class panel
-        tr = Trelliscope(iris_df, "Iris", path=temp_dir_name)
-        tr.set_panel(IFramePanel("img_panel", aspect_ratio=1.5, is_local=True))
-        tr.write_display()
-
-        # chain panel methods
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # add_panel then write_display (basic chain)
         tr = (
-            Trelliscope(iris_df, "Iris", path=temp_dir_name)
-            .set_panel(Panel("img_panel", aspect_ratio=1.5))
+            Trelliscope(df, "Iris", path=temp_dir)
+            .add_panel(pnl)
             .write_display()
         )
+        assert "img_panel" in tr._get_panel_columns()
 
-        # infer panels explicitly (chained)
-        # tr = (Trelliscope(iris_df, "Iris", path=temp_dir_name)
-        #     .infer_panels()
-        #     .write_display())
+        # add_panel with a fresh Trelliscope (non-chained)
+        tr2 = Trelliscope(df, "Iris", path=temp_dir)
+        tr2 = tr2.add_panel(pnl)
+        tr2 = tr2.write_display()
+        assert "img_panel" in tr2._get_panel_columns()
 
-        # infer panels implicitly
-        Trelliscope(iris_df, "Iris", path=temp_dir_name).write_display()
+        # infer_panels finds the already-added panel (no duplication)
+        tr3 = Trelliscope(df, "Iris", path=temp_dir).add_panel(pnl).infer_panels()
+        assert tr3._get_panel_columns().count("img_panel") == 1
+
+        # PanelOptions are stored and retrievable
+        opts = PanelOptions(width=800, height=600)
+        tr4 = (
+            Trelliscope(df, "Iris", path=temp_dir)
+            .set_panel_options({"img_panel": opts})
+            .add_panel(pnl)
+        )
+        assert tr4._get_panel_options("img_panel").width == 800
+        assert tr4._get_panel_options("unknown") is None
 
 
 def test_panel_options_init_default():

--- a/trelliscope/tests/test_state.py
+++ b/trelliscope/tests/test_state.py
@@ -50,6 +50,40 @@ def test_layout_state_init():
     assert state.page == expected_page
     assert state.type == State.TYPE_LAYOUT
     assert state.viewtype == LayoutState.VIEWTYPE_GRID
+    # New Phase 2 defaults
+    assert state.sidebar is True
+    assert state.visible_filters is None
+
+
+def test_layout_state_sidebar_and_visible_filters(iris_df):
+    state = LayoutState(ncol=2, sidebar=False, visible_filters=["Sepal.Length", "Species"])
+    assert state.sidebar is False
+    assert state.visible_filters == ["Sepal.Length", "Species"]
+    state.check_with_data(iris_df)
+
+
+def test_layout_state_visible_filters_unknown_column(iris_df):
+    state = LayoutState(visible_filters=["no_such_column"])
+    with pytest.raises(ValueError, match="references columns not in the data"):
+        state.check_with_data(iris_df)
+
+
+def test_layout_state_invalid_sidebar_type():
+    with pytest.raises(TypeError, match="must be a boolean"):
+        LayoutState(sidebar="yes")
+
+
+def test_layout_state_visible_filters_must_be_list():
+    with pytest.raises(ValueError, match="to be a list"):
+        LayoutState(visible_filters="Species")
+
+
+def test_layout_state_serializes_sidebar_and_visible_filters(iris_df):
+    state = LayoutState(ncol=3, sidebar=False, visible_filters=["Sepal.Length"])
+    state.check_with_data(iris_df)
+    d = state.to_dict()
+    assert d["sidebar"] is False
+    assert d["visible_filters"] == ["Sepal.Length"]
 
 
 def test_layout_state(iris_df):

--- a/trelliscope/tests/test_theme.py
+++ b/trelliscope/tests/test_theme.py
@@ -1,0 +1,142 @@
+import json
+import os
+import tempfile
+
+import pytest
+
+from trelliscope import Theme, Trelliscope
+from trelliscope.theme import Theme
+
+
+# ---------------------------------------------------------------------------
+# Theme construction
+# ---------------------------------------------------------------------------
+
+
+def test_theme_empty():
+    t = Theme()
+    assert t.is_custom is False
+
+
+def test_theme_with_primary():
+    t = Theme(primary="#ff0000")
+    assert t.primary == "#ff0000"
+    assert t.is_custom is True
+
+
+def test_theme_all_params():
+    t = Theme(
+        primary="#111",
+        primary2="#222",
+        primary3="#333",
+        background="#444",
+        background2="#555",
+        background3="#666",
+        bars="#777",
+        text="#888",
+        text2="#999",
+        button_text="#aaa",
+        text_disabled="#bbb",
+        error="#ccc",
+        font_family="sans-serif",
+        logo="https://example.com/logo.png",
+    )
+    assert t.is_custom is True
+    assert t.font_family == "sans-serif"
+    assert t.logo == "https://example.com/logo.png"
+
+
+def test_theme_invalid_color_type():
+    with pytest.raises(ValueError, match="CSS color string"):
+        Theme(primary=123)
+
+
+def test_theme_invalid_font_family_type():
+    with pytest.raises(ValueError, match="font_family"):
+        Theme(font_family=42)
+
+
+def test_theme_invalid_logo_type():
+    with pytest.raises(ValueError, match="logo"):
+        Theme(logo=["not", "a", "string"])
+
+
+# ---------------------------------------------------------------------------
+# Theme serialization
+# ---------------------------------------------------------------------------
+
+
+def test_theme_to_dict_empty():
+    d = Theme().to_dict()
+    assert d == {"isCustom": False}
+
+
+def test_theme_to_dict_camelcase_keys():
+    t = Theme(button_text="#fff", text_disabled="#ccc", font_family="Arial")
+    d = t.to_dict()
+    # Python snake_case attrs must be serialized as camelCase keys
+    assert "buttonText" in d
+    assert "textDisabled" in d
+    assert "fontFamily" in d
+    assert "button_text" not in d
+    assert "text_disabled" not in d
+    assert "font_family" not in d
+
+
+def test_theme_to_dict_only_non_none():
+    t = Theme(primary="#123", text="#abc")
+    d = t.to_dict()
+    assert d["primary"] == "#123"
+    assert d["text"] == "#abc"
+    assert "primary2" not in d
+    assert d["isCustom"] is True
+
+
+def test_theme_to_json():
+    t = Theme(primary="#abc")
+    parsed = json.loads(t.to_json())
+    assert parsed["primary"] == "#abc"
+    assert parsed["isCustom"] is True
+
+
+def test_theme_repr():
+    t = Theme(primary="#abc")
+    r = repr(t)
+    assert "Theme" in r
+    assert "primary" in r
+
+
+# ---------------------------------------------------------------------------
+# set_theme() on Trelliscope
+# ---------------------------------------------------------------------------
+
+
+def test_set_theme(iris_tr):
+    tr = iris_tr.set_theme(primary="#4C72B0", font_family="Helvetica")
+    assert tr.theme is not None
+    assert tr.theme.primary == "#4C72B0"
+    assert tr.theme.font_family == "Helvetica"
+
+
+def test_set_theme_does_not_mutate_original(iris_tr):
+    tr2 = iris_tr.set_theme(primary="#ff0000")
+    assert iris_tr.theme is None
+    assert tr2.theme.primary == "#ff0000"
+
+
+def test_set_theme_in_to_dict(iris_tr):
+    tr = iris_tr.set_theme(primary="#ff0000")
+    d = tr.to_dict()
+    assert d["theme"] is not None
+    assert d["theme"]["primary"] == "#ff0000"
+    assert d["theme"]["isCustom"] is True
+
+
+def test_no_theme_in_to_dict(iris_tr):
+    d = iris_tr.to_dict()
+    assert d["theme"] is None
+
+
+def test_set_theme_invalid_color(iris_tr):
+    with pytest.raises(ValueError, match="CSS color string"):
+        iris_tr.set_theme(primary=42)

--- a/trelliscope/tests/test_trelliscope.py
+++ b/trelliscope/tests/test_trelliscope.py
@@ -296,50 +296,43 @@ def test_infer_primary_panel(mars_df: pd.DataFrame):
     assert tr.primary_panel in ("img_src", "img2")
 
 
-@pytest.mark.skip(
-    "Need to find a new set of images to download, because nasa.gov is taking a long time."
-)
-def test_copy_images_to_build_directory(mars_df: pd.DataFrame):
-    mars_df = mars_df[:3]  # reduce to two rows
+def test_copy_images_to_build_directory():
+    """Local image files should be copied into the output directory on write_display()."""
+    import base64
+
+    # Minimal valid 1×1 white PNG — no external download needed
+    TINY_PNG = base64.b64decode(
+        b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+        b"+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    )
 
     with tempfile.TemporaryDirectory() as output_dir:
-        with tempfile.TemporaryDirectory() as temp_dir2:
-            # download the images to a temp directory and update the data frame
-            for i in range(len(mars_df)):
-                original_file = mars_df["img_src"][i]
-                file_name = os.path.basename(original_file)
-                temp_dir_file = os.path.join(temp_dir2, file_name)
+        with tempfile.TemporaryDirectory() as img_dir:
+            rows = []
+            for i in range(3):
+                img_path = os.path.join(img_dir, f"row_{i}.png")
+                with open(img_path, "wb") as f:
+                    f.write(TINY_PNG)
+                rows.append({"id": str(i), "value": float(i), "img_panel": img_path})
+            df = pd.DataFrame(rows)
 
-                # security check to disallow urls starting with file: or custom schemas.
-                if not original_file.startswith(("http:", "https:")):
-                    raise ValueError("URL must start with 'http:' or 'https:'")
-                else:
-                    with urllib.urlopen(original_file, timeout=1) as response, open(
-                        temp_dir_file, "wb"
-                    ) as out_file:
-                        shutil.copyfileobj(response, out_file)
-
-                mars_df["img_src"][i] = temp_dir_file
-
-            tr = Trelliscope(mars_df, "mars_rover", path=output_dir)
+            tr = Trelliscope(df, "test", path=output_dir)
             tr = tr.add_panel(
-                ImagePanel("img_src", FilePanelSource(True), should_copy_to_output=True)
+                ImagePanel("img_panel", FilePanelSource(True), should_copy_to_output=True)
             )
 
-            # At first, the image should be in the temp dir that we put it in
-            original_image = tr.data_frame["img_src"][0]
-            assert temp_dir2 in original_image
+            # Before write: paths point into img_dir
+            assert img_dir in tr.data_frame["img_panel"].iloc[0]
 
             tr = tr.write_display()
 
-            # Now the image should not be in the temp dir
-            new_image = tr.data_frame["img_src"][0]
-            new_image_full_path = os.path.join(tr.get_dataset_display_path(), new_image)
-            assert temp_dir2 not in new_image_full_path
+            # After write: paths must no longer point into the original img_dir
+            new_img = tr.data_frame["img_panel"].iloc[0]
+            full_path = os.path.join(tr.get_dataset_display_path(), new_img)
+            assert img_dir not in full_path
 
-            # But the image should exist in the output dir
-            assert output_dir in new_image_full_path
-            assert os.path.exists(new_image_full_path)
+            # And the copied file must actually exist in the output directory
+            assert os.path.exists(full_path)
 
 
 def test_set_default_sort(mars_df: pd.DataFrame):
@@ -412,14 +405,37 @@ def test_set_default_sort(mars_df: pd.DataFrame):
         tr.set_default_sort(["a", "b", "c"], ["asc", "desc"])
 
 
-@pytest.mark.skip("Need to better understand the rules of inferring states")
-def test_infer_state(mars_df: pd.DataFrame):
-    with tempfile.TemporaryDirectory() as output_dir:
-        tr = Trelliscope(mars_df, "mars_rover", path=output_dir)
-        tr._infer_state(tr.state)
+def test_infer_state(iris_df_no_duplicates):
+    import pandas as pd
+    from trelliscope.state import CategoryFilterState, DisplayState, LayoutState
 
-    raise NotImplementedError()
-    # TODO: Make sure to test the intersection of CategoryFilter levels and Factor meta levels.
+    df = iris_df_no_duplicates.copy()
+    df["Species"] = pd.Categorical(df["Species"])
+    df["img"] = "test.png"
+    pnl = ImagePanel("img", source=FilePanelSource(False), should_copy_to_output=False)
+    tr = Trelliscope(df, "test").add_panel(pnl).infer()
+
+    # Empty state → default LayoutState(ncol=3) and LabelState(key_cols)
+    inferred = tr._infer_state(DisplayState())
+    assert inferred.layout is not None
+    assert inferred.layout.ncol == 3
+    assert inferred.labels is not None
+    for key in tr.key_cols:
+        assert key in inferred.labels.varnames
+
+    # Existing layout is preserved, not overwritten
+    state_with_layout = DisplayState()
+    state_with_layout.set(LayoutState(ncol=5))
+    inferred2 = tr._infer_state(state_with_layout)
+    assert inferred2.layout.ncol == 5
+
+    # CategoryFilterState values are intersected with FactorMeta levels
+    state_with_filter = DisplayState()
+    cf = CategoryFilterState("Species", values=["setosa", "no_such_species"])
+    state_with_filter.set(cf)
+    inferred3 = tr._infer_state(state_with_filter)
+    assert "setosa" in inferred3.filter["Species"].values
+    assert "no_such_species" not in inferred3.filter["Species"].values
 
 
 def test_set_primary_panel(mars_df: pd.DataFrame):
@@ -610,3 +626,42 @@ def test_set_show_info_on_load_invalid_type(iris_tr):
 
 def test_has_info_false_by_default(iris_tr):
     assert iris_tr.to_dict()["hasInfo"] is False
+
+
+# ---------------------------------------------------------------------------
+# serve()
+# ---------------------------------------------------------------------------
+
+
+def test_serve_raises_before_write(iris_df_no_duplicates):
+    df = iris_df_no_duplicates.copy()
+    df["img"] = "test.png"
+    pnl = ImagePanel("img", source=FilePanelSource(False), should_copy_to_output=False)
+    tr = Trelliscope(df, "test").add_panel(pnl)
+    with pytest.raises(ValueError, match="write_display"):
+        tr.serve(port=19876)
+
+
+def test_serve_returns_self(iris_df_no_duplicates):
+    df = iris_df_no_duplicates.copy()
+    df["img"] = "test.png"
+    pnl = ImagePanel("img", source=FilePanelSource(False), should_copy_to_output=False)
+    with tempfile.TemporaryDirectory() as output_dir:
+        tr = Trelliscope(df, "test", path=output_dir).add_panel(pnl).write_display()
+        result = tr.serve(port=19877)
+        assert result is tr
+
+
+def test_serve_responds_to_http(iris_df_no_duplicates):
+    """The background server should return HTTP 200 for index.html."""
+    import time
+
+    df = iris_df_no_duplicates.copy()
+    df["img"] = "test.png"
+    pnl = ImagePanel("img", source=FilePanelSource(False), should_copy_to_output=False)
+    with tempfile.TemporaryDirectory() as output_dir:
+        tr = Trelliscope(df, "test", path=output_dir).add_panel(pnl).write_display()
+        tr.serve(port=19878)
+        time.sleep(0.3)  # let the daemon thread bind its socket
+        response = urllib.request.urlopen("http://localhost:19878/index.html", timeout=3)
+        assert response.getcode() == 200

--- a/trelliscope/tests/test_trelliscope.py
+++ b/trelliscope/tests/test_trelliscope.py
@@ -665,3 +665,27 @@ def test_serve_responds_to_http(iris_df_no_duplicates):
         time.sleep(0.3)  # let the daemon thread bind its socket
         response = urllib.request.urlopen("http://localhost:19878/index.html", timeout=3)
         assert response.getcode() == 200
+
+
+def test_save_figure_in_jupyter_event_loop(tmp_path):
+    """_save_figure succeeds even when called from inside a running event loop (Jupyter)."""
+    import asyncio
+    from unittest.mock import MagicMock
+
+    captured = {}
+
+    def fake_write_image(path):
+        captured["path"] = path
+        open(path, "wb").close()
+
+    mock_fig = MagicMock()
+    mock_fig.write_image.side_effect = fake_write_image
+
+    out = tmp_path / "out.png"
+
+    async def run():
+        Trelliscope._save_figure(mock_fig, str(out))
+
+    asyncio.run(run())
+    assert captured["path"] == str(out)
+    assert mock_fig.write_image.call_count == 1

--- a/trelliscope/tests/test_trelliscope.py
+++ b/trelliscope/tests/test_trelliscope.py
@@ -517,3 +517,96 @@ def test_set_var_labels_applied_during_infer(iris_df_no_duplicates):
 def test_set_var_labels_invalid_type(iris_tr):
     with pytest.raises(ValueError, match="string"):
         iris_tr.set_var_labels(Species=123)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: set_default_layout (sidebar + visible_filters)
+# ---------------------------------------------------------------------------
+
+
+def test_set_default_layout_sidebar(iris_df_no_duplicates):
+    tr = Trelliscope(iris_df_no_duplicates, name="iris")
+    tr = tr.set_default_layout(ncol=2, sidebar=False)
+    assert tr.state.layout.sidebar is False
+    assert tr.state.layout.ncol == 2
+
+
+def test_set_default_layout_visible_filters(iris_df_no_duplicates):
+    tr = Trelliscope(iris_df_no_duplicates, name="iris")
+    tr = tr.set_default_layout(ncol=3, visible_filters=["Species", "Sepal.Length"])
+    assert tr.state.layout.visible_filters == ["Species", "Sepal.Length"]
+
+
+def test_set_default_layout_visible_filters_unknown_col(iris_df_no_duplicates):
+    from trelliscope.state import LayoutState
+
+    tr = Trelliscope(iris_df_no_duplicates, name="iris")
+    with pytest.raises(ValueError, match="references columns not in the data"):
+        tr.set_default_layout(visible_filters=["no_such_col"])
+
+
+def test_set_default_layout_serialized(iris_df_no_duplicates):
+    tr = Trelliscope(iris_df_no_duplicates, name="iris")
+    tr = tr.set_default_layout(ncol=4, sidebar=False, visible_filters=["Species"])
+    d = tr.state.layout.to_dict()
+    assert d["sidebar"] is False
+    assert d["visible_filters"] == ["Species"]
+    assert d["ncol"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: set_info_html and set_show_info_on_load
+# ---------------------------------------------------------------------------
+
+
+def test_set_info_html(iris_tr):
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".html", delete=False
+    ) as f:
+        f.write("<h1>Hello Trelliscope</h1>")
+        html_path = f.name
+
+    try:
+        tr = iris_tr.set_info_html(html_path)
+        assert tr.info_html == "<h1>Hello Trelliscope</h1>"
+        assert tr.to_dict()["hasInfo"] is True
+    finally:
+        os.unlink(html_path)
+
+
+def test_set_info_html_missing_file(iris_tr):
+    with pytest.raises(ValueError, match="not found"):
+        iris_tr.set_info_html("/nonexistent/path/info.html")
+
+
+def test_set_info_html_does_not_mutate_original(iris_tr):
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:
+        f.write("<p>test</p>")
+        html_path = f.name
+
+    try:
+        tr2 = iris_tr.set_info_html(html_path)
+        assert iris_tr.info_html is None
+        assert tr2.info_html is not None
+    finally:
+        os.unlink(html_path)
+
+
+def test_set_show_info_on_load(iris_tr):
+    tr = iris_tr.set_show_info_on_load(True)
+    assert tr.show_info_on_load is True
+    assert tr.to_dict()["infoOnLoad"] is True
+
+
+def test_set_show_info_on_load_default_false(iris_tr):
+    assert iris_tr.show_info_on_load is False
+    assert iris_tr.to_dict()["infoOnLoad"] is False
+
+
+def test_set_show_info_on_load_invalid_type(iris_tr):
+    with pytest.raises(TypeError, match="must be a boolean"):
+        iris_tr.set_show_info_on_load("yes")
+
+
+def test_has_info_false_by_default(iris_tr):
+    assert iris_tr.to_dict()["hasInfo"] is False

--- a/trelliscope/tests/test_trelliscope.py
+++ b/trelliscope/tests/test_trelliscope.py
@@ -447,11 +447,73 @@ def test_infer_panels(mars_df: pd.DataFrame):
         assert tr.primary_panel == "img_src"
 
 
-@pytest.mark.skip("Test these when inputs are functioning")
-def test_add_input(mars_df: pd.DataFrame):
-    raise NotImplementedError
+def test_add_input(iris_tr):
+    from trelliscope.input import TextInput
+
+    inp = TextInput("notes", label="Notes", width=60, height=4)
+    tr = iris_tr.add_input(inp)
+
+    assert "notes" in tr.inputs
+    assert tr.inputs["notes"].label == "Notes"
 
 
-@pytest.mark.skip("Test these when inputs are functioning")
-def test_add_inputs(mars_df: pd.DataFrame):
-    raise NotImplementedError
+def test_add_inputs(iris_tr):
+    from trelliscope.input import NumberInput, RadioInput, TextInput
+
+    inputs = [
+        TextInput("comments", label="Comments"),
+        RadioInput("quality", label="Quality", options=["good", "bad"]),
+        NumberInput("score", label="Score", min=0, max=10),
+    ]
+    tr = iris_tr.add_inputs(inputs, email="test@example.com", vars=["Species"])
+
+    assert len(tr.inputs) == 3
+    assert tr.input_email == "test@example.com"
+    assert tr.input_vars == ["Species"]
+
+
+def test_add_inputs_serialized(iris_tr):
+    from trelliscope.input import RadioInput, TextInput
+
+    inputs = [
+        TextInput("notes"),
+        RadioInput("flag", options=["yes", "no"]),
+    ]
+    tr = iris_tr.add_inputs(inputs, email="user@test.com")
+    d = tr.to_dict()
+
+    assert d["inputs"] is not None
+    assert len(d["inputs"]) == 2
+    assert d["inputEmailAddr"] == "user@test.com"
+    types = {i["type"] for i in d["inputs"]}
+    assert types == {"text", "radio"}
+
+
+def test_set_var_labels(iris_tr):
+    tr = iris_tr.set_var_labels(Species="Species Name", **{"Sepal.Length": "Sepal Length (cm)"})
+
+    assert tr.var_labels["Species"] == "Species Name"
+    assert tr.var_labels["Sepal.Length"] == "Sepal Length (cm)"
+
+
+def test_set_var_labels_applied_to_existing_meta(iris_df_no_duplicates):
+    from trelliscope.metas import StringMeta
+
+    tr = Trelliscope(iris_df_no_duplicates, name="iris")
+    tr = tr.set_meta(StringMeta("Species"))
+    tr = tr.set_var_labels(Species="Species Name")
+
+    assert tr.metas["Species"].label == "Species Name"
+
+
+def test_set_var_labels_applied_during_infer(iris_df_no_duplicates):
+    tr = Trelliscope(iris_df_no_duplicates, name="iris")
+    tr = tr.set_var_labels(**{"Sepal.Length": "Sepal Length (cm)"})
+    tr = tr._infer_metas()
+
+    assert tr.metas["Sepal.Length"].label == "Sepal Length (cm)"
+
+
+def test_set_var_labels_invalid_type(iris_tr):
+    with pytest.raises(ValueError, match="string"):
+        iris_tr.set_var_labels(Species=123)

--- a/trelliscope/tests/test_trelliscope.py
+++ b/trelliscope/tests/test_trelliscope.py
@@ -667,9 +667,8 @@ def test_serve_responds_to_http(iris_df_no_duplicates):
         assert response.getcode() == 200
 
 
-def test_save_figure_in_jupyter_event_loop(tmp_path):
-    """_save_figure succeeds even when called from inside a running event loop (Jupyter)."""
-    import asyncio
+def test_save_figure_calls_write_image(tmp_path):
+    """_save_figure delegates to fig.write_image for Plotly figures."""
     from unittest.mock import MagicMock
 
     captured = {}
@@ -682,10 +681,36 @@ def test_save_figure_in_jupyter_event_loop(tmp_path):
     mock_fig.write_image.side_effect = fake_write_image
 
     out = tmp_path / "out.png"
+    Trelliscope._save_figure(mock_fig, str(out))
 
-    async def run():
-        Trelliscope._save_figure(mock_fig, str(out))
-
-    asyncio.run(run())
     assert captured["path"] == str(out)
     assert mock_fig.write_image.call_count == 1
+
+
+def test_write_display_in_jupyter_event_loop(iris_df_no_duplicates, tmp_path):
+    """write_display() works when called from inside a running event loop (Jupyter)."""
+    import asyncio
+    from unittest.mock import MagicMock
+
+    df = iris_df_no_duplicates.copy()
+
+    def make_mock_fig():
+        fig = MagicMock()
+        fig.write_image.side_effect = lambda path: open(path, "wb").close()
+        return fig
+
+    df["panel"] = [make_mock_fig() for _ in range(len(df))]
+
+    async def run():
+        from trelliscope.panel_source import FilePanelSource
+        from trelliscope.panels import FigurePanel
+        pnl = FigurePanel("panel", source=FilePanelSource(False))
+        tr = (
+            Trelliscope(df, "test", path=str(tmp_path))
+            .add_panel(pnl)
+            .write_display()
+        )
+        return tr
+
+    tr = asyncio.run(run())
+    assert tr is not None

--- a/trelliscope/tests/test_view.py
+++ b/trelliscope/tests/test_view.py
@@ -1,6 +1,11 @@
 import json
 
-from trelliscope.state import LabelState, SortState
+import pytest
+
+from trelliscope import Trelliscope
+from trelliscope.panel_source import FilePanelSource
+from trelliscope.panels import ImagePanel
+from trelliscope.state import CategoryFilterState, LayoutState, LabelState, SortState
 from trelliscope.view import View
 
 # Note, when using json results, we are converting the json to dictionaries
@@ -32,3 +37,72 @@ def test_create_view_with_state_parameters():
     actual_json = view.to_json(pretty=False)
     expected_json = '{"name":"test view","state":{"layout":null,"labels":{"varnames":["manufacturer","class"],"type":"labels"},"sort":[{"metatype":null,"dir":"asc","varname":"manufacturer","type":"sort"}],"filter":[]}}'
     assert json.loads(actual_json) == json.loads(expected_json)
+
+
+def test_view_with_layout_state():
+    v = View("v", layout_state=LayoutState(ncol=4))
+    assert v.state.layout.ncol == 4
+
+
+def test_view_with_filter_states_list():
+    v = View(
+        "v",
+        filter_states=[
+            CategoryFilterState("a", values=["x"]),
+            CategoryFilterState("b", values=["y"]),
+        ],
+    )
+    assert "a" in v.state.filter
+    assert "b" in v.state.filter
+
+
+def test_view_with_sort_states_list():
+    v = View("v", sort_states=[SortState("a"), SortState("b")])
+    assert "a" in v.state.sort
+    assert "b" in v.state.sort
+
+
+def test_view_to_json_pretty_vs_compact():
+    v = View("v", layout_state=LayoutState(ncol=2))
+    assert "\n" in v.to_json(pretty=True)
+    assert "\n" not in v.to_json(pretty=False)
+
+
+def test_view_copy_is_independent():
+    v = View("original", layout_state=LayoutState(ncol=2))
+    v2 = v._copy()
+    v2.name = "copy"
+    v2.state.layout.ncol = 99
+    assert v.name == "original"
+    assert v.state.layout.ncol == 2
+
+
+def test_trelliscope_add_view(iris_df_no_duplicates):
+    df = iris_df_no_duplicates.copy()
+    df["img"] = "test.png"
+    pnl = ImagePanel("img", source=FilePanelSource(False), should_copy_to_output=False)
+    tr = Trelliscope(df, "test").add_panel(pnl).add_view(View("sorted_view", sort_state=SortState("Sepal.Length")))
+    assert "sorted_view" in tr.views
+
+
+def test_trelliscope_add_view_replaces_existing(iris_df_no_duplicates):
+    df = iris_df_no_duplicates.copy()
+    df["img"] = "test.png"
+    pnl = ImagePanel("img", source=FilePanelSource(False), should_copy_to_output=False)
+    tr = (
+        Trelliscope(df, "test")
+        .add_panel(pnl)
+        .add_view(View("v", layout_state=LayoutState(ncol=1)))
+        .add_view(View("v", layout_state=LayoutState(ncol=5)))
+    )
+    assert tr.views["v"].state.layout.ncol == 5
+
+
+def test_trelliscope_add_view_immutable(iris_df_no_duplicates):
+    df = iris_df_no_duplicates.copy()
+    df["img"] = "test.png"
+    pnl = ImagePanel("img", source=FilePanelSource(False), should_copy_to_output=False)
+    tr = Trelliscope(df, "test").add_panel(pnl)
+    tr2 = tr.add_view(View("myview"))
+    assert "myview" not in tr.views
+    assert "myview" in tr2.views

--- a/trelliscope/theme.py
+++ b/trelliscope/theme.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+
+
+class Theme:
+    """
+    Defines visual theming for a Trelliscope display.
+
+    All color parameters accept CSS color strings (e.g. "#4C72B0", "rgb(76,114,176)",
+    "steelblue"). The logo parameter accepts a URL or a base64 data URI.
+    """
+
+    _COLOR_PARAMS = [
+        "primary",
+        "primary2",
+        "primary3",
+        "background",
+        "background2",
+        "background3",
+        "bars",
+        "text",
+        "text2",
+        "button_text",
+        "text_disabled",
+        "error",
+    ]
+
+    # Maps Python snake_case attribute names to the camelCase keys the JS viewer expects.
+    _ATTR_TO_KEY = {
+        "primary": "primary",
+        "primary2": "primary2",
+        "primary3": "primary3",
+        "background": "background",
+        "background2": "background2",
+        "background3": "background3",
+        "bars": "bars",
+        "text": "text",
+        "text2": "text2",
+        "button_text": "buttonText",
+        "text_disabled": "textDisabled",
+        "error": "error",
+        "font_family": "fontFamily",
+        "logo": "logo",
+    }
+
+    def __init__(
+        self,
+        primary: str = None,
+        primary2: str = None,
+        primary3: str = None,
+        background: str = None,
+        background2: str = None,
+        background3: str = None,
+        bars: str = None,
+        text: str = None,
+        text2: str = None,
+        button_text: str = None,
+        text_disabled: str = None,
+        error: str = None,
+        font_family: str = None,
+        logo: str = None,
+    ):
+        for param in self._COLOR_PARAMS:
+            val = locals()[param]
+            if val is not None and not isinstance(val, str):
+                raise ValueError(
+                    f"Theme color parameter '{param}' must be a CSS color string, "
+                    f"got {type(val).__name__}."
+                )
+
+        if font_family is not None and not isinstance(font_family, str):
+            raise ValueError("Theme 'font_family' must be a string.")
+        if logo is not None and not isinstance(logo, str):
+            raise ValueError("Theme 'logo' must be a string (URL or data URI).")
+
+        self.primary = primary
+        self.primary2 = primary2
+        self.primary3 = primary3
+        self.background = background
+        self.background2 = background2
+        self.background3 = background3
+        self.bars = bars
+        self.text = text
+        self.text2 = text2
+        self.button_text = button_text
+        self.text_disabled = text_disabled
+        self.error = error
+        self.font_family = font_family
+        self.logo = logo
+
+    @property
+    def is_custom(self) -> bool:
+        return any(getattr(self, attr) is not None for attr in self._ATTR_TO_KEY)
+
+    def to_dict(self) -> dict:
+        result = {}
+        for attr, key in self._ATTR_TO_KEY.items():
+            val = getattr(self, attr)
+            if val is not None:
+                result[key] = val
+        result["isCustom"] = self.is_custom
+        return result
+
+    def to_json(self, pretty: bool = True) -> str:
+        return json.dumps(self.to_dict(), indent=2 if pretty else None)
+
+    def __repr__(self) -> str:
+        custom = {k: v for k, v in self._ATTR_TO_KEY.items() if getattr(self, k) is not None}
+        return f"Theme(is_custom={self.is_custom}, params={list(custom.keys())})"

--- a/trelliscope/trelliscope.py
+++ b/trelliscope/trelliscope.py
@@ -1235,26 +1235,8 @@ class Trelliscope:
     def _save_figure(fig, filepath: str) -> None:
         """Save a figure to disk, dispatching on Plotly vs matplotlib."""
         if hasattr(fig, "write_image"):
-            import asyncio
-            import concurrent.futures
-
-            # kaleido 1.x uses asyncio.run() internally. In Jupyter notebooks
-            # an event loop is already running, which causes asyncio.run() to
-            # raise RuntimeError ("Did you set 0 or less tabs?"). Running
-            # write_image in a worker thread avoids this because threads start
-            # with no event loop, so kaleido's asyncio.run() can create one.
             try:
-                asyncio.get_running_loop()
-                _in_jupyter = True
-            except RuntimeError:
-                _in_jupyter = False
-
-            try:
-                if _in_jupyter:
-                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
-                        ex.submit(fig.write_image, filepath).result()
-                else:
-                    fig.write_image(filepath)
+                fig.write_image(filepath)
             except ValueError as e:
                 if "kaleido" in str(e).lower():
                     raise ValueError(
@@ -1396,18 +1378,33 @@ class Trelliscope:
                     )
                 else:
                     progress_bar = ProgressBar(len(tr.data_frame), "Saving Images:")
-                    tr.data_frame[panel_col] = tr.data_frame.apply(
-                        lambda row: Trelliscope.__write_figure(
-                            row=row,
-                            fig_column=panel.figure_varname,
-                            output_dir_for_writing=absolute_output_dir,
-                            output_dir_for_dataframe=relative_output_dir,
-                            extension=extension,
-                            key_cols=tr.key_cols,
-                            progress_bar=progress_bar,
-                        ),
-                        axis=1,
-                    )
+
+                    def _apply_write_figures(_tr=tr, _pb=progress_bar):
+                        return _tr.data_frame.apply(
+                            lambda row: Trelliscope.__write_figure(
+                                row=row,
+                                fig_column=panel.figure_varname,
+                                output_dir_for_writing=absolute_output_dir,
+                                output_dir_for_dataframe=relative_output_dir,
+                                extension=extension,
+                                key_cols=_tr.key_cols,
+                                progress_bar=_pb,
+                            ),
+                            axis=1,
+                        )
+
+                    # kaleido 1.x uses asyncio.run() internally, which fails
+                    # when Jupyter's event loop is already running. All figures
+                    # must be written in a single worker thread so that kaleido
+                    # can create and reuse one event loop across every figure.
+                    import asyncio
+                    import concurrent.futures
+                    try:
+                        asyncio.get_running_loop()
+                        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+                            tr.data_frame[panel_col] = ex.submit(_apply_write_figures).result()
+                    except RuntimeError:
+                        tr.data_frame[panel_col] = _apply_write_figures()
 
             if not skip_render:
                 tr._write_keysig(panel_col, current_keysig)
@@ -1793,8 +1790,11 @@ class Trelliscope:
             def log_message(self_h, *args):
                 pass
 
-        httpd = HTTPServer(("", port), _Handler)
-        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        try:
+            httpd = HTTPServer(("", port), _Handler)
+            threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        except OSError:
+            pass  # port already bound from a previous call — server still running
 
         url = Trelliscope._build_viewer_url(port)
 
@@ -1911,6 +1911,15 @@ class Trelliscope:
                 "No files exist for this Trelliscope exist. Before viewing the Trelliscope, "
                 + "ensure that the `write_display` method has been called."
             )
+
+        # In Jupyter: serve via HTTP and render an IFrame inline in the cell.
+        # webbrowser.open("file://...") cannot embed in a notebook output cell.
+        try:
+            ip = get_ipython()  # type: ignore[name-defined]
+            if ip is not None:
+                return self.serve()
+        except NameError:
+            pass
 
         full_path = "file://" + os.path.realpath(index_file)
 

--- a/trelliscope/trelliscope.py
+++ b/trelliscope/trelliscope.py
@@ -25,6 +25,7 @@ from trelliscope.metas import (
 )
 from trelliscope.panels import FigurePanel, ImagePanel, Panel, PanelOptions
 from trelliscope.progress_bar import ProgressBar
+from trelliscope.theme import Theme
 from trelliscope.state import (
     CategoryFilterState,
     DisplayState,
@@ -139,6 +140,9 @@ class Trelliscope:
         self.input_email: str = None
         self.input_vars: list = None
         self.var_labels: dict = {}
+        self.theme: Theme = None
+        self.info_html: str = None
+        self.show_info_on_load: bool = False
 
     def _infer_primary_panel(self) -> None:
         """
@@ -388,6 +392,9 @@ class Trelliscope:
         result["inputVars"] = self.input_vars
         result["thumbnailurl"] = self.thumbnail_url
         result["primarypanel"] = self.primary_panel
+        result["theme"] = self.theme.to_dict() if self.theme is not None else None
+        result["hasInfo"] = self.info_html is not None
+        result["infoOnLoad"] = self.show_info_on_load
 
         return result
 
@@ -524,6 +531,7 @@ class Trelliscope:
 
         tr = tr._check_panels()
         tr = tr._infer_thumbnail_url()
+        tr._write_info_html()
 
         tr._write_display_info(jsonp, config["id"])
         tr._write_meta_data(config["id"])
@@ -1366,18 +1374,28 @@ class Trelliscope:
 
         return tr
 
-    def set_default_layout(self, ncol: int = 1, page: int = 1):
+    def set_default_layout(
+        self,
+        ncol: int = 1,
+        page: int = 1,
+        sidebar: bool = True,
+        visible_filters: list = None,
+    ):
         """
         Add a layout state specification to a trelliscope display.
+
         Params:
-            ncol:int - The number of columns.
-            page:int - The number of pages.
+            ncol:int - The number of panel columns in the grid.
+            page:int - The initial page number.
+            sidebar:bool - Whether the filter sidebar is open by default.
+            visible_filters:list - Variable names whose filter controls start
+                expanded in the sidebar. If None, all are collapsed.
 
         Returns a copy of the Trelliscope object. The original is not modified.
         """
         tr = self.__copy()
 
-        layout_state = LayoutState(ncol, page)
+        layout_state = LayoutState(ncol, page, sidebar, visible_filters)
         layout_state.check_with_data(tr.data_frame)
 
         state2 = tr.state._copy()
@@ -1385,6 +1403,115 @@ class Trelliscope:
 
         tr = tr.set_state(state2)
         return tr
+
+    def set_theme(
+        self,
+        primary: str = None,
+        primary2: str = None,
+        primary3: str = None,
+        background: str = None,
+        background2: str = None,
+        background3: str = None,
+        bars: str = None,
+        text: str = None,
+        text2: str = None,
+        button_text: str = None,
+        text_disabled: str = None,
+        error: str = None,
+        font_family: str = None,
+        logo: str = None,
+    ):
+        """
+        Set visual theme colors and fonts for this display.
+
+        All color parameters accept CSS color strings (e.g. "#4C72B0",
+        "rgb(76,114,176)", "steelblue"). Unspecified parameters take the
+        viewer's built-in defaults.
+
+        Params:
+            primary: Main brand / accent color.
+            primary2: Secondary accent color.
+            primary3: Tertiary accent color.
+            background: Main background color.
+            background2: Secondary background color.
+            background3: Tertiary background color.
+            bars: Color for bars / progress indicators.
+            text: Primary text color.
+            text2: Secondary text color.
+            button_text: Button label color.
+            text_disabled: Disabled text color.
+            error: Error / warning highlight color.
+            font_family: CSS font-family string.
+            logo: URL or base64 data URI for a logo image.
+
+        Returns a copy of the Trelliscope object. The original is not modified.
+        """
+        tr = self.__copy()
+        tr.theme = Theme(
+            primary=primary,
+            primary2=primary2,
+            primary3=primary3,
+            background=background,
+            background2=background2,
+            background3=background3,
+            bars=bars,
+            text=text,
+            text2=text2,
+            button_text=button_text,
+            text_disabled=text_disabled,
+            error=error,
+            font_family=font_family,
+            logo=logo,
+        )
+        return tr
+
+    def set_info_html(self, file: str):
+        """
+        Set custom HTML content for the info panel of this display.
+
+        The file's content is read and stored. When write_display() is called,
+        it is written as info.html in the display directory, and displayInfo
+        will indicate hasInfo=True so the viewer can load it.
+
+        Params:
+            file:str - Path to an HTML file to use as the info panel.
+
+        Returns a copy of the Trelliscope object. The original is not modified.
+        """
+        tr = self.__copy()
+
+        if not os.path.isfile(file):
+            raise ValueError(f"Info HTML file not found: '{file}'")
+
+        with open(file) as f:
+            tr.info_html = f.read()
+
+        return tr
+
+    def set_show_info_on_load(self, show: bool = True):
+        """
+        Control whether the info panel opens automatically when the display loads.
+
+        Params:
+            show:bool - True to auto-open the info panel; False (default) to keep it closed.
+
+        Returns a copy of the Trelliscope object. The original is not modified.
+        """
+        tr = self.__copy()
+        utils.check_bool(show, "show")
+        tr.show_info_on_load = show
+        return tr
+
+    def _write_info_html(self) -> None:
+        """
+        Writes info.html to the dataset display directory if info_html content has been set.
+        """
+        if self.info_html is None:
+            return
+
+        info_html_path = os.path.join(self.get_dataset_display_path(), "info.html")
+        with open(info_html_path, "w") as f:
+            f.write(self.info_html)
 
     def set_default_sort(
         self, varnames: list, sort_directions: list = None, add: bool = False

--- a/trelliscope/trelliscope.py
+++ b/trelliscope/trelliscope.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import glob
+import hashlib
 import json
 import logging
 import os
@@ -23,7 +24,7 @@ from trelliscope.metas import (
     PanelMeta,
     StringMeta,
 )
-from trelliscope.panels import FigurePanel, ImagePanel, Panel, PanelOptions
+from trelliscope.panels import FigurePanel, ImagePanel, LazyPanel, Panel, PanelOptions
 from trelliscope.progress_bar import ProgressBar
 from trelliscope.theme import Theme
 from trelliscope.state import (
@@ -525,7 +526,7 @@ class Trelliscope:
             if (panel.is_writeable or panel.should_copy) and (
                 not panel.panels_written or force_write
             ):
-                tr = tr.write_or_copy_panels(panel_col)
+                tr = tr.write_or_copy_panels(panel_col, force_write=force_write)
 
         tr = tr.infer()
 
@@ -564,6 +565,10 @@ class Trelliscope:
         panel_cols = tr._get_panel_columns()
 
         for panel_col in panel_cols:
+            panel = tr._get_panel(panel_col)
+            if panel.is_lazy and panel_col not in tr.data_frame.columns:
+                # Lazy panels are written at write time; column may not exist beforehand.
+                continue
             if panel_col not in tr.data_frame.columns:
                 raise ValueError(
                     f"Panel column '{panel_col}' is not present in the data frame."
@@ -970,6 +975,21 @@ class Trelliscope:
         if len(panel_cols) == 0:
             # No panels exist yet
 
+            # Check for callable columns (lazy panels)
+            obj_cols = [
+                col
+                for col in tr.data_frame.columns
+                if utils.is_object_dtype(tr.data_frame[col])
+            ]
+            for column in obj_cols:
+                if utils.is_callable_column(tr.data_frame, column):
+                    fn = tr.data_frame[column][0]
+                    panel = LazyPanel(column, fn=fn)
+                    tr = tr.add_panel(panel)
+
+            # Refresh panel_cols after lazy panel detection
+            panel_cols = tr._get_panel_columns()
+
             # Check for a `Figure` col
             figure_columns = utils.find_figure_columns(tr.data_frame)
 
@@ -1078,7 +1098,11 @@ class Trelliscope:
         This used because when writing panels, the `varname` column will be updated to contain
         the filename, but the original figure is preserved in this "figure" column.
         """
-        figure_columns = [panel.figure_varname for panel in self.panels.values()]
+        figure_columns = [
+            panel.figure_varname
+            for panel in self.panels.values()
+            if panel.figure_varname is not None
+        ]
 
         return figure_columns
 
@@ -1195,6 +1219,30 @@ class Trelliscope:
         html_utils.write_id_file(output_path=output_path, trelliscope_id=self.id)
 
     @staticmethod
+    def _get_panel_filename(row, key_cols: list, output_dir: str, extension: str) -> str:
+        """Compute the output file path for a single panel image row."""
+        if len(key_cols) > 0:
+            key_col_values = [str(row[key_col]) for key_col in key_cols]
+            filename_prefix = "_".join(key_col_values)
+        else:
+            filename_prefix = str(row.name)
+        filename_prefix = utils.sanitize(filename_prefix)
+        return os.path.join(output_dir, f"{filename_prefix}.{extension}")
+
+    @staticmethod
+    def _save_figure(fig, filepath: str) -> None:
+        """Save a figure to disk, dispatching on Plotly vs matplotlib."""
+        if hasattr(fig, "write_image"):
+            fig.write_image(filepath)
+        elif hasattr(fig, "savefig"):
+            fig.savefig(filepath, bbox_inches="tight")
+        else:
+            raise ValueError(
+                f"Unsupported figure type '{type(fig).__name__}'. "
+                "Expected a Plotly Figure or a matplotlib Figure."
+            )
+
+    @staticmethod
     def __write_figure(
         row,
         fig_column: str,
@@ -1205,58 +1253,61 @@ class Trelliscope:
         progress_bar: ProgressBar = None,
     ):
         """
-        Saves a figure object to an image file. This function is designed to be passed to
-        a DataFrame.apply() call to write out each figure.
-        Params:
-            row - The DataFrame row
-            fig_column:str - The name of the figure column to write out
-            output_dir_for_writing:str - Used for writing the image. It is most likely an
-                absolute path.
-            output_dir_for_dataframe:str - Used for the result in the dataframe. It is most likely a
-                relative path.
-            extension:str - The file name extension to write (for example, "png")
-            key_cols:str - The columns that are used as the key (ie, index, group by) for this figure
+        Saves a figure object to an image file. Designed to be passed to DataFrame.apply().
         """
         fig = row[fig_column]
 
-        filename_prefix = ""
-        if len(key_cols) > 0:
-            key_col_values = [str(row[key_col]) for key_col in key_cols]
-            filename_prefix = "_".join(key_col_values)
-        else:
-            filename_prefix = row.name
-
-        filename_prefix = utils.sanitize(filename_prefix)
-
-        filename_for_writing = os.path.join(
-            output_dir_for_writing, f"{filename_prefix}.{extension}"
+        filename_for_writing = Trelliscope._get_panel_filename(
+            row, key_cols, output_dir_for_writing, extension
         )
-        filename_for_dataframe = os.path.join(
-            output_dir_for_dataframe, f"{filename_prefix}.{extension}"
+        filename_for_dataframe = Trelliscope._get_panel_filename(
+            row, key_cols, output_dir_for_dataframe, extension
         )
 
-        # logging.debug(f"Saving image {filename_for_writing}")
-        fig.write_image(filename_for_writing)
+        Trelliscope._save_figure(fig, filename_for_writing)
 
         try:
             progress_bar.record_progress()
         except Exception as e:
-            # If the progress display has a problem, just ignore it.
             logging.debug(f"Error recording progress: {e}")
-            pass
 
         return filename_for_dataframe
 
-    def write_or_copy_panels(self, panel_col: str):
+    def _compute_panel_keysig(self) -> str:
+        """Compute an MD5 hash of key column values to detect data changes between runs."""
+        key_values = self.data_frame[self.key_cols].astype(str).values.flatten().tolist()
+        content = "|".join(key_values)
+        return hashlib.md5(content.encode()).hexdigest()
+
+    def _read_stored_keysig(self, panel_col: str) -> str:
+        """Read the persisted keysig for a panel column. Returns None if absent."""
+        keysig_file = os.path.join(
+            self._get_panel_output_path(panel_col, is_absolute=True), ".keysig"
+        )
+        if os.path.isfile(keysig_file):
+            with open(keysig_file) as f:
+                return f.read().strip()
+        return None
+
+    def _write_keysig(self, panel_col: str, keysig: str) -> None:
+        """Persist the keysig for a panel column so future runs can skip unchanged panels."""
+        keysig_file = os.path.join(
+            self._get_panel_output_path(panel_col, is_absolute=True), ".keysig"
+        )
+        with open(keysig_file, "w") as f:
+            f.write(keysig)
+
+    def write_or_copy_panels(self, panel_col: str, force_write: bool = False):
         """
         Writes the panels to the output directory (or copies them if they are already files).
+
+        Params:
+            panel_col:str - The name of the panel column.
+            force_write:bool - If True, panels are always re-written even if unchanged.
         """
         tr = self.__copy()
 
-        panel = self._get_panel(panel_col)
-
-        # if not (panel.is_writeable or panel.should_copy):
-        #     raise ValueError("Error: Attempting to write a panel that is not writable or should not be copied")
+        panel = tr._get_panel(panel_col)
 
         absolute_output_dir = tr._get_panel_output_path(panel_col, is_absolute=True)
         relative_output_dir = tr._get_panel_output_path(panel_col, is_absolute=False)
@@ -1264,44 +1315,70 @@ class Trelliscope:
         if not os.path.isdir(absolute_output_dir):
             os.makedirs(absolute_output_dir)
 
-        # TODO: check if the panel is an html widget, and if so, create it here (see R)
-
         if panel.should_copy:
             tr._copy_images_to_build_directory(
                 panel_col, absolute_output_dir, relative_output_dir
             )
         elif panel.is_writeable:
-            # panel_keys = tr._get_panel_paths_from_keys()
             extension = panel.get_extension()
 
-            # TODO: Follow the logic in the R version to match filenames, etc.
-            # tr.data_frame["__PANEL_KEY__"] = tr.data_frame.apply(lambda row: Trelliscope.__write_figure(row, panel_col, output_dir, extension, self.key_cols), axis=1)
+            # Keysig cache: skip rendering if the key data hasn't changed
+            current_keysig = tr._compute_panel_keysig()
+            stored_keysig = tr._read_stored_keysig(panel_col)
+            skip_render = (not force_write) and (stored_keysig == current_keysig)
 
-            # TODO: Do we want to overwrite the current panel column (which is full of figure objects)
-            # with the new one full of filenames? Or should we create a new one and just make sure that the old
-            # one is excluded from the metas list, etc.
+            if panel.is_lazy:
+                # Lazy panel: generate figures via fn(row) at write time
+                progress_bar = ProgressBar(len(tr.data_frame), "Generating Panels:")
+                results = []
+                for _, row in tr.data_frame.iterrows():
+                    filename_for_dataframe = Trelliscope._get_panel_filename(
+                        row, tr.key_cols, relative_output_dir, extension
+                    )
+                    if not skip_render:
+                        filename_for_writing = Trelliscope._get_panel_filename(
+                            row, tr.key_cols, absolute_output_dir, extension
+                        )
+                        fig = panel.fn(row)
+                        Trelliscope._save_figure(fig, filename_for_writing)
+                        try:
+                            progress_bar.record_progress()
+                        except Exception as e:
+                            logging.debug(f"Error recording progress: {e}")
+                    results.append(filename_for_dataframe)
+                tr.data_frame[panel_col] = results
+            else:
+                # Regular figure panel: figures already live in df[panel_col]
+                tr.data_frame[panel.figure_varname] = tr.data_frame[panel_col]
 
-            # SB: For now, let's preserve the old with another column
-            tr.data_frame[panel.figure_varname] = tr.data_frame[panel_col]
+                if skip_render:
+                    logging.info(
+                        f"Skipping render for '{panel_col}': key data unchanged (keysig match)."
+                    )
+                    tr.data_frame[panel_col] = tr.data_frame.apply(
+                        lambda row: Trelliscope._get_panel_filename(
+                            row, tr.key_cols, relative_output_dir, extension
+                        ),
+                        axis=1,
+                    )
+                else:
+                    progress_bar = ProgressBar(len(tr.data_frame), "Saving Images:")
+                    tr.data_frame[panel_col] = tr.data_frame.apply(
+                        lambda row: Trelliscope.__write_figure(
+                            row=row,
+                            fig_column=panel.figure_varname,
+                            output_dir_for_writing=absolute_output_dir,
+                            output_dir_for_dataframe=relative_output_dir,
+                            extension=extension,
+                            key_cols=tr.key_cols,
+                            progress_bar=progress_bar,
+                        ),
+                        axis=1,
+                    )
 
-            progress_bar = ProgressBar(len(tr.data_frame), "Saving Images:")
-
-            tr.data_frame[panel_col] = tr.data_frame.apply(
-                lambda row: Trelliscope.__write_figure(
-                    row=row,
-                    fig_column=panel_col,
-                    output_dir_for_writing=absolute_output_dir,
-                    output_dir_for_dataframe=relative_output_dir,
-                    extension=extension,
-                    key_cols=self.key_cols,
-                    progress_bar=progress_bar,
-                ),
-                axis=1,
-            )
-
-            # TODO: Handle creating hash and key sig to avoid having to re-write panels
-            # that have already been generated here.
-            # One of the things that needs to happen here is to set the keysig to a hash of the columns
+            if not skip_render:
+                tr._write_keysig(panel_col, current_keysig)
+            tr.keysig = current_keysig
 
         panel.panels_written = True
 

--- a/trelliscope/trelliscope.py
+++ b/trelliscope/trelliscope.py
@@ -1235,17 +1235,35 @@ class Trelliscope:
     def _save_figure(fig, filepath: str) -> None:
         """Save a figure to disk, dispatching on Plotly vs matplotlib."""
         if hasattr(fig, "write_image"):
+            import asyncio
+            import concurrent.futures
+
+            # kaleido 1.x uses asyncio.run() internally. In Jupyter notebooks
+            # an event loop is already running, which causes asyncio.run() to
+            # raise RuntimeError ("Did you set 0 or less tabs?"). Running
+            # write_image in a worker thread avoids this because threads start
+            # with no event loop, so kaleido's asyncio.run() can create one.
             try:
-                fig.write_image(filepath)
+                asyncio.get_running_loop()
+                _in_jupyter = True
+            except RuntimeError:
+                _in_jupyter = False
+
+            try:
+                if _in_jupyter:
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+                        ex.submit(fig.write_image, filepath).result()
+                else:
+                    fig.write_image(filepath)
             except ValueError as e:
                 if "kaleido" in str(e).lower():
                     raise ValueError(
                         "Plotly could not export an image because kaleido is not "
-                        "working in this environment.\n\n"
-                        "kaleido 0.2.x requires a Chromium browser binary, which is "
-                        "not available in some environments (e.g. SageMaker, Docker). "
-                        "Install the self-contained 0.1.x build instead:\n\n"
-                        "    pip install 'kaleido==0.1.0.post1'\n\n"
+                        "installed or not working in this environment.\n\n"
+                        "Install kaleido:\n\n"
+                        "    pip install kaleido\n\n"
+                        "If you are in SageMaker, also run:\n\n"
+                        "    plotly_get_chrome\n\n"
                         "Then restart your kernel/session."
                     ) from None
                 raise

--- a/trelliscope/trelliscope.py
+++ b/trelliscope/trelliscope.py
@@ -1233,7 +1233,20 @@ class Trelliscope:
     def _save_figure(fig, filepath: str) -> None:
         """Save a figure to disk, dispatching on Plotly vs matplotlib."""
         if hasattr(fig, "write_image"):
-            fig.write_image(filepath)
+            try:
+                fig.write_image(filepath)
+            except ValueError as e:
+                if "kaleido" in str(e).lower():
+                    raise ValueError(
+                        "Plotly could not export an image because kaleido is not "
+                        "working in this environment.\n\n"
+                        "kaleido 0.2.x requires a Chromium browser binary, which is "
+                        "not available in some environments (e.g. SageMaker, Docker). "
+                        "Install the self-contained 0.1.x build instead:\n\n"
+                        "    pip install 'kaleido==0.1.0.post1'\n\n"
+                        "Then restart your kernel/session."
+                    ) from None
+                raise
         elif hasattr(fig, "savefig"):
             fig.savefig(filepath, bbox_inches="tight")
         else:

--- a/trelliscope/trelliscope.py
+++ b/trelliscope/trelliscope.py
@@ -334,6 +334,8 @@ class Trelliscope:
         """
         Returns the output path where the Trelliscope is saved.
         """
+        if self.path is None:
+            return None
         return os.path.join(self.path, self._get_name_dir())
 
     def get_displays_path(self) -> str:
@@ -1736,6 +1738,147 @@ class Trelliscope:
             panel_options = self.panel_options[panel_name]
 
         return panel_options
+
+    def serve(self, port: int = 8765):
+        """
+        Start a local HTTP server for this display and print the URL to open.
+
+        Automatically detects the execution environment:
+        - SageMaker Studio   → prints the ``/proxy/<port>/`` URL for your domain.
+        - SageMaker Classic  → prints the notebook-instance proxy URL.
+        - Jupyter (local)    → prints ``http://localhost:<port>/`` and embeds an IFrame.
+        - CLI                → prints ``http://localhost:<port>/``.
+
+        The server runs in a background daemon thread and shuts down when the
+        Python process exits.  Call ``write_display()`` before ``serve()``.
+
+        Params:
+            port:int - Port to listen on (default 8765).
+
+        Returns self so it can be chained after ``write_display()``.
+        """
+        import threading
+        from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+        output_path = self.get_output_path()
+        if output_path is None or not os.path.exists(os.path.join(output_path, "index.html")):
+            raise ValueError(
+                "No display output found. Call write_display() before serve()."
+            )
+
+        serve_dir = output_path
+
+        class _Handler(SimpleHTTPRequestHandler):
+            def __init__(self_h, *args, **kwargs):
+                super().__init__(*args, directory=serve_dir, **kwargs)
+
+            def log_message(self_h, *args):
+                pass
+
+        httpd = HTTPServer(("", port), _Handler)
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+
+        url = Trelliscope._build_viewer_url(port)
+
+        # Embed an IFrame only in plain Jupyter (not SageMaker — the proxy URL
+        # requires browser-level auth, so the IFrame would be blocked).
+        in_sagemaker = os.path.exists("/opt/ml/metadata/resource-metadata.json") or \
+            os.path.isdir("/home/ec2-user/SageMaker")
+        if not in_sagemaker:
+            try:
+                ip = get_ipython()  # type: ignore[name-defined]
+                if ip is not None:
+                    from IPython.display import IFrame
+                    from IPython.display import display as ipy_display
+                    ipy_display(IFrame(url, width="100%", height=650))
+            except NameError:
+                pass
+
+        return self
+
+    @staticmethod
+    def _build_viewer_url(port: int) -> str:
+        """
+        Detect the execution environment and return the correct viewer URL,
+        printing human-readable guidance to stdout.
+        """
+        _PROXY_TIP = (
+            "\nTip: if you see 403 Forbidden, your SageMaker domain may restrict\n"
+            "proxy access.  Download the output folder and open index.html locally,\n"
+            "or ask your AWS administrator to enable PresignedUrl / proxy access."
+        )
+
+        # ---- SageMaker Studio ------------------------------------------------
+        studio_meta = "/opt/ml/metadata/resource-metadata.json"
+        if os.path.exists(studio_meta):
+            try:
+                with open(studio_meta) as f:
+                    meta = json.load(f)
+                domain_id = meta.get("DomainId", "")
+                if domain_id:
+                    try:
+                        import boto3
+                        region = boto3.session.Session().region_name or "us-east-1"
+                    except Exception:
+                        region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+                    url = (
+                        f"https://{domain_id}.studio.{region}.sagemaker.aws"
+                        f"/jupyter/default/proxy/{port}/"
+                    )
+                    print(f"SageMaker Studio detected.")
+                    print(f"Open this URL in your browser:\n  {url}")
+                    print(_PROXY_TIP)
+                    return url
+            except Exception:
+                pass
+
+        # ---- SageMaker Classic Notebook --------------------------------------
+        if os.path.isdir("/home/ec2-user/SageMaker"):
+            nb_name = os.environ.get("NOTEBOOK_NAME", "")
+            if not nb_name:
+                for path in (
+                    "/home/ec2-user/.sagemaker/metadata.json",
+                    "/opt/ml/metadata/resource-metadata.json",
+                ):
+                    if os.path.exists(path):
+                        try:
+                            with open(path) as f:
+                                nb_name = json.load(f).get("ResourceName", "")
+                            if nb_name:
+                                break
+                        except Exception:
+                            pass
+            try:
+                import boto3
+                region = boto3.session.Session().region_name or "us-east-1"
+            except Exception:
+                region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+
+            if nb_name:
+                url = f"https://{nb_name}.notebook.{region}.sagemaker.aws/proxy/{port}/"
+                print("SageMaker Classic Notebook detected.")
+            else:
+                url = f"http://localhost:{port}/"
+                print(
+                    "SageMaker Classic Notebook detected but notebook name could not\n"
+                    "be determined automatically — using localhost URL as fallback."
+                )
+            print(f"Open this URL in your browser:\n  {url}")
+            print(_PROXY_TIP)
+            return url
+
+        # ---- Generic Jupyter or CLI ------------------------------------------
+        url = f"http://localhost:{port}/"
+        try:
+            ip = get_ipython()  # type: ignore[name-defined]
+            if ip is not None:
+                print(f"Open this URL in your browser:\n  {url}")
+                return url
+        except NameError:
+            pass
+
+        print(f"Trelliscope server running at:\n  {url}")
+        return url
 
     def view_trelliscope(self):
         """

--- a/trelliscope/trelliscope.py
+++ b/trelliscope/trelliscope.py
@@ -136,6 +136,9 @@ class Trelliscope:
 
         self.views = {}
         self.inputs = {}
+        self.input_email: str = None
+        self.input_vars: list = None
+        self.var_labels: dict = {}
 
     def _infer_primary_panel(self) -> None:
         """
@@ -287,9 +290,15 @@ class Trelliscope:
 
         return tr
 
-    def add_inputs(self, inputs: list):
+    def add_inputs(self, inputs: list, email: str = None, vars: list = None):
         """
-        Convenience method to add muliple inputs.
+        Convenience method to add multiple inputs, with optional email export settings.
+
+        Params:
+            inputs: list of Input objects to add.
+            email: Optional email address used to export annotations as CSV.
+            vars: Optional list of variable names to include in the CSV export alongside
+                the input annotations.
 
         Returns a copy of the Trelliscope object. The original is not modified.
         """
@@ -297,6 +306,16 @@ class Trelliscope:
 
         for input_obj in inputs:
             tr = tr.add_input(input_obj)
+
+        if email is not None:
+            if not isinstance(email, str):
+                raise ValueError("'email' must be a string.")
+            tr.input_email = email
+
+        if vars is not None:
+            if not isinstance(vars, list):
+                raise ValueError("'vars' must be a list of variable names.")
+            tr.input_vars = vars
 
         return tr
 
@@ -360,11 +379,13 @@ class Trelliscope:
         result["state"] = self.state.to_dict()
         result["views"] = [view.to_dict() for view in self.views.values()]
 
-        if self.inputs.values is None or len(self.inputs.values()) == 0:
+        if len(self.inputs) == 0:
             result["inputs"] = None
         else:
-            result["inputs"] = [input.to_dict() for input in self.inputs.values()]
+            result["inputs"] = [inp.to_dict() for inp in self.inputs.values()]
 
+        result["inputEmailAddr"] = self.input_email
+        result["inputVars"] = self.input_vars
         result["thumbnailurl"] = self.thumbnail_url
         result["primarypanel"] = self.primary_panel
 
@@ -520,19 +541,39 @@ class Trelliscope:
 
     def _check_panels(self):
         """
-        Checks the files in the panels directory, then compares them against the
-        key columns in the dataframe. If there are key columns that do not have
-        corresponding files, it will throw an error specifying the extra key columns
-        that were discovered.
+        Validates panel columns against the dataframe and internal state.
+
+        Checks:
+        - Every declared panel column exists in the dataframe.
+        - No panel column contains all-null values.
+        - The primary_panel (if set) refers to a declared panel.
 
         Throws:
             ValueError
         """
         tr = self.__copy()
 
-        os.path.join(tr.get_displays_path(), "panels")
+        panel_cols = tr._get_panel_columns()
 
-        # TODO: Fill this in
+        for panel_col in panel_cols:
+            if panel_col not in tr.data_frame.columns:
+                raise ValueError(
+                    f"Panel column '{panel_col}' is not present in the data frame."
+                )
+            if tr.data_frame[panel_col].isna().all():
+                raise ValueError(
+                    f"Panel column '{panel_col}' contains only null values."
+                )
+            if tr.data_frame[panel_col].isna().any():
+                logging.warning(
+                    f"Panel column '{panel_col}' contains some null values."
+                )
+
+        if tr.primary_panel is not None and tr.primary_panel not in tr.panels:
+            raise ValueError(
+                f"Primary panel '{tr.primary_panel}' is not a declared panel. "
+                f"Available panels: {panel_cols}"
+            )
 
         return tr
 
@@ -794,28 +835,20 @@ class Trelliscope:
 
     def _finalize_meta_labels(self):
         """
-        Fill in the labels for any metas that do not have a label. It will
-        use the varname by default.
+        Fill in the labels for any metas that do not have a label, using this priority:
+        1. user-supplied label from set_var_labels()
+        2. varname as fallback
 
         Returns a copy of the Trelliscope object. The original is not modified.
         """
-        # This is how this is inferred in the R code...
-        # Finalize labels if NULL with the following priority:
-        # 1. use from disp$meta_labels if defined
-        # 2. use from attr(disp$df[[varname]], "label") if defined
-        # 3. set it to varname
-
-        # TODO: See if there is a Pandas equivalent to a column label
-        # that is separate from the column name. It appears this R
-        # functionality is not present in Pandas
-
-        # TODO: if tr.__copy() doesn't make copies of metas, this needs
-        # to make copies of the metas here before changing the label
         tr = self.__copy()
 
-        for meta in self.metas.values():
+        for meta in tr.metas.values():
             if meta.label is None:
-                meta.label = meta.varname
+                if meta.varname in tr.var_labels:
+                    meta.label = tr.var_labels[meta.varname]
+                else:
+                    meta.label = meta.varname
 
         return tr
 
@@ -1282,6 +1315,36 @@ class Trelliscope:
     # Currently unused.
     # def add_meta_labels(self):
     #     return self.__copy()
+
+    def set_var_labels(self, **labels):
+        """
+        Set human-readable display labels for one or more meta variables.
+
+        Labels are applied immediately to any already-defined metas and are
+        also stored so they are applied to metas inferred later during
+        `write_display()`.
+
+        Params:
+            **labels: Keyword arguments mapping varname to label string.
+                e.g. set_var_labels(country="Country Name", life_exp="Life Expectancy")
+
+        Returns a copy of the Trelliscope object. The original is not modified.
+        """
+        tr = self.__copy()
+
+        for varname, label in labels.items():
+            if not isinstance(label, str):
+                raise ValueError(
+                    f"Label for '{varname}' must be a string, got {type(label).__name__}."
+                )
+
+        tr.var_labels.update(labels)
+
+        for varname, label in labels.items():
+            if varname in tr.metas:
+                tr.metas[varname].label = label
+
+        return tr
 
     def set_default_labels(self, varnames: list):
         """

--- a/trelliscope/utils.py
+++ b/trelliscope/utils.py
@@ -442,17 +442,20 @@ def find_figure_columns(df: pd.DataFrame):
 
 def is_figure_column(df: pd.DataFrame, col: str):
     """
-    Determine if the column is explicitly filled with `Figure` objects.
+    Determine if the column is filled with figure objects (Plotly or matplotlib).
 
     Params:
         df:pd.DataFrame - The dataframe
         col:str - The column to check
     """
     is_figure = False
+    first = df[col][0]
 
-    if isinstance(df[col][0], plotly.graph_objs.Figure):
-        # The first row is a Figure, check all now
+    if isinstance(first, plotly.graph_objs.Figure):
         if df[col].apply(lambda x: isinstance(x, plotly.graph_objs.Figure)).all():
+            is_figure = True
+    elif is_matplotlib_figure(first):
+        if df[col].apply(lambda x: is_matplotlib_figure(x)).all():
             is_figure = True
 
     return is_figure
@@ -678,6 +681,41 @@ def is_string_column(column: pd.Series):
             is_string = True
 
     return is_string
+
+
+def is_matplotlib_figure(obj) -> bool:
+    """Returns True if obj is a matplotlib Figure; False if matplotlib is not installed."""
+    try:
+        import matplotlib.figure
+
+        return isinstance(obj, matplotlib.figure.Figure)
+    except ImportError:
+        return False
+
+
+def is_matplotlib_figure_column(df: pd.DataFrame, col: str) -> bool:
+    """Returns True if the column is entirely filled with matplotlib Figure objects."""
+    if not is_object_dtype(df[col]):
+        return False
+    try:
+        import matplotlib.figure
+
+        first = df[col][0]
+        if not isinstance(first, matplotlib.figure.Figure):
+            return False
+        return df[col].apply(lambda x: isinstance(x, matplotlib.figure.Figure)).all()
+    except ImportError:
+        return False
+
+
+def is_callable_column(df: pd.DataFrame, col: str) -> bool:
+    """Returns True if the column contains only callable objects (for lazy panels)."""
+    if not is_object_dtype(df[col]):
+        return False
+    first = df[col][0]
+    if not callable(first):
+        return False
+    return df[col].dropna().apply(callable).all()
 
 
 def is_datetime_column(column: pd.Series, must_be_datetime_objects: bool):

--- a/trelliscope/utils.py
+++ b/trelliscope/utils.py
@@ -342,11 +342,46 @@ def check_exhaustive_levels(
 def check_graph_var(
     df: pd.DataFrame, varname: str, id_varname: str, get_error_message_function
 ):
-    """ """
-    # TODO: After we have determined how to handle the graph data in Pandas,
-    # implement this method to verify it.
+    """
+    Verify that a graph variable column contains valid graph data. Each cell
+    must be None/NaN or a list of dicts where every dict contains id_varname.
+    Params:
+        df: Pandas DataFrame
+        varname: The graph column to validate
+        id_varname: The key that must be present in every link dict
+        get_error_message_function: The function to call to get the error message template
+    Raises:
+        ValueError - If the check fails.
+    """
+    col = df[varname]
 
-    raise NotImplementedError()
+    for i, value in enumerate(col):
+        if value is None:
+            continue
+        if isinstance(value, float) and pd.isna(value):
+            continue
+        if not isinstance(value, list):
+            raise ValueError(
+                get_error_message_function(
+                    f"Graph column '{varname}' row {i} must be a list of dicts, "
+                    f"got {type(value).__name__}."
+                )
+            )
+        for j, item in enumerate(value):
+            if not isinstance(item, dict):
+                raise ValueError(
+                    get_error_message_function(
+                        f"Graph column '{varname}' row {i}, item {j} must be a dict, "
+                        f"got {type(item).__name__}."
+                    )
+                )
+            if id_varname not in item:
+                raise ValueError(
+                    get_error_message_function(
+                        f"Graph column '{varname}' row {i}, item {j} is missing "
+                        f"required key '{id_varname}'."
+                    )
+                )
 
 
 valid_image_extensions = {

--- a/trelliscope/view.py
+++ b/trelliscope/view.py
@@ -5,9 +5,6 @@ from .state import DisplayState, FilterState, LabelState, LayoutState, SortState
 
 
 class View:
-    # TODO: Verify desirable API around passing in states
-    # Should they be a list? Should it just be the display obj?
-    # Should we keep an option for both single sort and multiple sort?
     def __init__(
         self,
         name: str,
@@ -59,5 +56,4 @@ class View:
         return json.dumps(self.to_dict(), indent=indent_value)
 
     def _copy(self):
-        # TODO: Shallow or deep copy??
         return copy.deepcopy(self)


### PR DESCRIPTION
Summary

  This PR brings the Python port substantially closer to parity with Ryan Hafen's R reference implementation. It was developed across four phases, each adding a focused set of features, bug fixes, and tests.

  ---
  Phase 1 — Input system, meta casting, graph validation, panel checks, var labels

  - input.py — Complete rewrite from a 12-line skeleton into a full 7-class input system: TextInput, NumberInput, RadioInput, CheckboxInput, SelectInput, MultiselectInput (all inheriting from Input). Each class serializes to a typed dict/JSON payload consumed by the JS viewer.
  - metas.py — Three targeted fixes:
    - FactorMeta.cast_variable(): was raise NotImplementedError; now correctly converts the column to pd.Categorical using inferred or explicit levels.
    - GeoMeta.to_dict(): was silently dropping latvar/longvar from serialization, which broke the JS viewer; fixed to include all attributes.
    - GeoMeta.cast_variable(): new method (stub was missing entirely).
  - utils.py — check_graph_var() was raise NotImplementedError; now validates that every cell is None/NaN or a list of dicts each containing the required id_varname key.
  - trelliscope.py — Several fixes:
    - _check_panels() implemented (was a stub).
    - set_var_labels(**labels) new method; labels apply immediately to existing metas and are stored for metas inferred later.
    - _finalize_meta_labels() bug fix: was iterating self.metas (original) instead of tr.metas (copy).
    - to_dict() bug fix: self.inputs.values is None (always False) replaced with len(self.inputs) == 0.
    - add_inputs() extended with email and vars parameters.
  - pyproject.toml — kaleido==0.1.* → kaleido>=0.2.0 (0.1.x is no longer published on PyPI).
  - Tests added: test_input.py (32 tests), test_metas.py additions (7 tests), test_trelliscope.py additions.

  ---
  Phase 2 — Theming, sidebar/visible-filters layout, and info HTML panel

  - theme.py — New Theme class with 14 configurable attributes (primary, background, font_family, logo, etc.). Serializes with camelCase JSON keys (buttonText, textDisabled, fontFamily) and an isCustom flag. Fully immutable — set_theme() returns a deep copy.
  - state.py — LayoutState extended with sidebar: bool = True and visible_filters: list = None. Both are validated, checked against the dataframe in check_with_data(), and serialized to dict.
  - trelliscope.py — New methods:
    - set_theme(primary, ..., font_family, logo) — fluent API wrapping Theme.
    - set_info_html(file) — reads an HTML file into info_html; written as info.html at write time; sets hasInfo=True in displayInfo.
    - set_show_info_on_load(show) — controls infoOnLoad in displayInfo.
    - set_default_layout() extended with sidebar and visible_filters params.
    - to_dict() — now includes inputEmailAddr, inputVars, theme, hasInfo, infoOnLoad.
  - __init__.py — exports Theme and all 6 input types.
  - Tests added: test_theme.py (20 tests), test_state.py additions (5 tests), test_trelliscope.py additions.

  ---
  Phase 3 — Lazy panels, keysig caching, matplotlib support

  - panels.py — New LazyPanel(varname, fn, extension, aspect_ratio) class. fn receives a pd.Series row and must return a Plotly or matplotlib figure. Evaluated per-row at write time. Auto-detected during infer_panels() when a DataFrame column is entirely callable. is_lazy flag added to base Panel.
  - trelliscope.py:
    - _save_figure(fig, filepath) — dispatches on fig.write_image (Plotly) vs fig.savefig (matplotlib).
    - _get_panel_filename(row, key_cols, dir, ext) — shared path-generation helper used by both render and skip-render paths.
    - _compute_panel_keysig() / _read_stored_keysig() / _write_keysig() — MD5 hash of key column values, persisted as .keysig beside the panel images. Subsequent write_display() calls skip re-rendering when data is unchanged.
    - write_or_copy_panels(panel_col, force_write=False) — integrated keysig check; handles lazy panels via per-row fn loop; always populates file paths in the DataFrame regardless of skip.
    - _check_panels() — skips pre-write column-existence check for lazy panels.
    - _get_panel_figure_columns() — filters None entries (lazy panels without a backup column).
  - utils.py — is_matplotlib_figure(), is_matplotlib_figure_column(), is_callable_column(); is_figure_column() updated to detect matplotlib figures alongside Plotly.
  - __init__.py — exports LazyPanel.

  ---
  Phase 4 — test_infer.py and README quick-start

  - test_infer.py — 19 new tests covering: key-column inference (single string, multi-column, raises when no unique combo); number/string/factor/href meta inference; non-meta column ignored; panel column becomes PanelMeta; figure backup column excluded from metas; lazy panel auto-detection and explicit add; label fallback to varname; default layout and label state inference.
  - README.md — Added a Quick Start section with three working end-to-end examples: Plotly figures, LazyPanel, and matplotlib figures.

  ---
  Test plan

  - python3 -m pytest trelliscope/tests/ — 199 passed, 3 skipped (pre-existing skips), 0 failures
  - Review test_input.py, test_theme.py, test_infer.py as the primary new test files
  - Smoke-test the README Plotly example locally with plotly installed
  - Verify LazyPanel writes panels correctly by running trelliscope/examples/